### PR TITLE
Fixes for radio bridge connection

### DIFF
--- a/lib/usb-device-wrapper.ts
+++ b/lib/usb-device-wrapper.ts
@@ -122,14 +122,14 @@ export class DAPWrapper {
     // We wait on errors as immediately after flash the micro:bit won't be ready to respond
     this._deviceId = await this.readMem32WaitOnError(FICR.DEVICE_ID_1);
 
-    this._pageSize = await this.cortexM.readMem32(FICR.CODEPAGESIZE);
-    this._numPages = await this.cortexM.readMem32(FICR.CODESIZE);
+    this._pageSize = await this.readMem32WaitOnError(FICR.CODEPAGESIZE);
+    this._numPages = await this.readMem32WaitOnError(FICR.CODESIZE);
   }
 
   async readMem32WaitOnError(register: number): Promise<number> {
     let retries = 0;
     let lastError: Error | undefined;
-    while (retries < 10) {
+    while (retries < 20) {
       try {
         return await this.cortexM.readMem32(register);
       } catch (e) {
@@ -137,7 +137,7 @@ export class DAPWrapper {
           lastError = e;
           if (/^Transfer/.test(e.message)) {
             retries++;
-            await new Promise((resolve) => setTimeout(resolve, 10));
+            await new Promise((resolve) => setTimeout(resolve, 20));
           } else {
             throw e;
           }

--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -116,9 +116,7 @@ export class MicrobitRadioBridgeConnection
       message: "Serial connect start",
     });
 
-    if (this.delegate.status !== ConnectionStatus.CONNECTED) {
-      await this.delegate.connect();
-    }
+    await this.delegate.connect();
 
     try {
       this.serialSession = new RadioBridgeSerialSession(


### PR DESCRIPTION
- Always have the usb delegate connect so transport is open
- Up the try agains and timeout for `readMem32WaitOnError`
- Use `readMem32WaitOnError` for all mem32 calls inside `reconnectAsync`. I've seen the subsequent calls fail, I don't know why.