### PR TITLE
Limit progress callbacks

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -209,12 +209,14 @@ const createFlashSection = (): Section => {
           if (file) {
             const text = await file.text();
             if (connection.flash) {
+              console.time("flash");
               await connection.flash(createUniversalHexFlashDataSource(text), {
                 partial: true,
                 progress: (percentage: number | undefined) => {
                   console.log(percentage);
                 },
               });
+              console.timeEnd("flash");
             }
           }
         },


### PR DESCRIPTION
Set it to a reasonable value by default that gives somewhat smooth progress bars.

At least temporarily I'm going to use a higher value in ml-trainer.