### PR TITLE
Needs to be with a response

### DIFF
--- a/lib/accelerometer-service.ts
+++ b/lib/accelerometer-service.ts
@@ -100,9 +100,7 @@ export class AccelerometerService implements Service {
     const dataView = new DataView(new ArrayBuffer(2));
     dataView.setUint16(0, value, true);
     return this.queueGattOperation(() =>
-      this.accelerometerPeriodCharacteristic.writeValueWithoutResponse(
-        dataView,
-      ),
+      this.accelerometerPeriodCharacteristic.writeValue(dataView),
     );
   }
 


### PR DESCRIPTION
Previously this worked on Windows but not Mac.
We'll switch to writeValueWithResponse (the non-deprecated version) in a separate PR.