### PR TITLE
Improve serial error logging

### DIFF
--- a/lib/device.ts
+++ b/lib/device.ts
@@ -179,7 +179,7 @@ export class DeviceConnectionEventMap {
   "status": ConnectionStatusEvent;
   "serialdata": SerialDataEvent;
   "serialreset": Event;
-  "serialerror": Event;
+  "serialerror": SerialErrorEvent;
   "flash": Event;
   "beforerequestdevice": Event;
   "afterrequestdevice": Event;

--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -13,6 +13,7 @@ import {
   DeviceConnection,
   DeviceConnectionEventMap,
   SerialDataEvent,
+  SerialErrorEvent,
 } from "./device.js";
 import { TypedEventTarget } from "./events.js";
 import { Logging, NullLogging } from "./logging.js";
@@ -223,8 +224,8 @@ class RadioBridgeSerialSession {
   private connectionCheckIntervalId: ReturnType<typeof setInterval> | undefined;
   private isRestartingConnection: boolean = false;
 
-  private serialErrorListener = (e: unknown) => {
-    this.logging.error("Serial error", e);
+  private serialErrorListener = (event: SerialErrorEvent) => {
+    this.logging.error("SerialError:", event.error);
     void this.dispose();
   };
 


### PR DESCRIPTION
We previously passed `e` to the `serialErrorListener` which was just a non-specific event. We now pass a typed event where we can specifically log the error.