### PR TITLE
Add error logging for bluetooth connection failure

### DIFF
--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -430,6 +430,7 @@ export const createBluetoothDeviceWrapper = async (
     await bluetooth.connect();
     return bluetooth;
   } catch (e) {
+    logging.error("Bluetooth connect error", e);
     return undefined;
   }
 };


### PR DESCRIPTION
Unfortunately, we recieved the model number error when the connect promise resolves, which can be before or after this catch block runs. I'm not sure there is a way around this, as the connect promise can hang around indefinitely for macOS.