### PR TITLE
Disconnect quietly when failing to connect via WebUSB

### DIFF
--- a/lib/device.ts
+++ b/lib/device.ts
@@ -189,7 +189,7 @@ export interface DeviceConnection<M extends ValueIsEvent<M>>
   /**
    * Disconnect from the device.
    */
-  disconnect(quiet?: boolean): Promise<void>;
+  disconnect(): Promise<void>;
 
   /**
    * Write serial data to the device.

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -189,7 +189,7 @@ export interface DeviceConnection<M extends ValueIsEvent<M>>
   /**
    * Disconnect from the device.
    */
-  disconnect(): Promise<void>;
+  disconnect(quiet?: boolean): Promise<void>;
 
   /**
    * Write serial data to the device.

--- a/lib/usb.ts
+++ b/lib/usb.ts
@@ -354,26 +354,30 @@ class MicrobitWebUSBConnectionImpl
     });
   }
 
-  async disconnect(): Promise<void> {
+  async disconnect(quiet?: boolean): Promise<void> {
     try {
       if (this.connection) {
         await this.stopSerialInternal();
         await this.connection.disconnectAsync();
       }
     } catch (e) {
-      this.log("Error during disconnection:\r\n" + e);
-      this.logging.event({
-        type: "WebUSB-error",
-        message: "error-disconnecting",
-      });
+      if (!quiet) {
+        this.log("Error during disconnection:\r\n" + e);
+        this.logging.event({
+          type: "WebUSB-error",
+          message: "error-disconnecting",
+        });
+      }
     } finally {
       this.connection = undefined;
       this.setStatus(ConnectionStatus.DISCONNECTED);
-      this.logging.log("Disconnection complete");
-      this.logging.event({
-        type: "WebUSB-info",
-        message: "disconnected",
-      });
+      if (!quiet) {
+        this.logging.log("Disconnection complete");
+        this.logging.event({
+          type: "WebUSB-info",
+          message: "disconnected",
+        });
+      }
     }
   }
 
@@ -402,7 +406,7 @@ class MicrobitWebUSBConnectionImpl
       // Disconnect from the microbit.
       // Any new connection reallocates all the internals.
       // Use the top-level API so any listeners reflect that we're disconnected.
-      await this.disconnect();
+      await this.disconnect(true);
 
       const enriched = enrichedError(e);
       // Sanitise error message, replace all special chars with '-', if last char is '-' remove it


### PR DESCRIPTION
This avoids logging disconnect events when the device wasn't connected in the first place.