### PR TITLE
Ignore delegate status on radio bridge disconnect

### DIFF
--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -209,7 +209,9 @@ class MicrobitRadioBridgeConnectionImpl
     }
     this.serialSessionOpen = false;
     this.disconnectPromise = (async () => {
+      this.ignoreDelegateStatus = true;
       await this.serialSession?.dispose(true);
+      this.ignoreDelegateStatus = false;
       this.disconnectPromise = undefined;
     })();
   }

--- a/lib/usb.ts
+++ b/lib/usb.ts
@@ -189,7 +189,7 @@ class MicrobitWebUSBConnectionImpl
         setTimeout(() => {
           if (this.status === ConnectionStatus.CONNECTED) {
             this.unloading = false;
-            if (this.addedListeners.serialdata) {
+            if (this.listeningToSerialData) {
               this.startSerialInternal();
             }
           }
@@ -202,9 +202,7 @@ class MicrobitWebUSBConnectionImpl
   private logging: Logging;
   private deviceSelectionMode: DeviceSelectionMode;
 
-  private addedListeners: Record<string, number> = {
-    serialdata: 0,
-  };
+  private listeningToSerialData = false;
 
   constructor(options: MicrobitWebUSBConnectionOptions = {}) {
     super();
@@ -337,7 +335,7 @@ class MicrobitWebUSBConnectionImpl
         await this.disconnect();
         this.visibilityReconnect = true;
       } else {
-        if (this.addedListeners.serialdata) {
+        if (this.listeningToSerialData) {
           this.log("Reinstating serial after flash");
           if (this.connection.daplink) {
             await this.connection.daplink.connect();
@@ -493,7 +491,7 @@ class MicrobitWebUSBConnectionImpl
     } else {
       await withTimeout(this.connection.reconnectAsync(), 10_000);
     }
-    if (this.addedListeners.serialdata && !this.flashing) {
+    if (this.listeningToSerialData && !this.flashing) {
       this.startSerialInternal();
     }
     this.setStatus(ConnectionStatus.CONNECTED);
@@ -569,7 +567,7 @@ class MicrobitWebUSBConnectionImpl
           this.startSerialInternal();
         }
         // Allows for reinstating serial after flashing.
-        this.addedListeners.serialdata++;
+        this.listeningToSerialData = true;
         break;
       }
     }
@@ -579,7 +577,7 @@ class MicrobitWebUSBConnectionImpl
     switch (type as keyof SerialConnectionEventMap) {
       case "serialdata": {
         this.stopSerialInternal();
-        this.addedListeners.serialdata--;
+        this.listeningToSerialData = false;
         break;
       }
     }


### PR DESCRIPTION
When calling disconnect on MicrobitRadioBridgeConnection, `this.serialSession?.dispose(true)` is called which removes the serialdata listener once, giving `this.addedListeners.serialdata` a value of 0. Due to the boolean passed in, we disconnect the delegate, which causes a disconnected event to be picked up by the `MicrobitRadioBridgeConnection` `delegateStatusListener`. This in turn calls `this.serialSession?.dispose()` for the second time, removing the serialdata listener a second time. `this.addedListeners.serialdata` is now a truthy value of -1. This results in errors somewhere further in the process because a check using `this.addedListeners.serialdata` is now doing the wrong thing.

~~An alternative approach to fixing would be to ensure that `this.addedListeners.serialdata` cannot be set to a negative value.~~

This needs both approaches. `ignoreDelegateStatus` solves half a problem and makes sense to have, but unplugging the radio link device (after this disconnect) calls the same dispose code in the `delegateStatusListener`. Make the serial data listener a boolean. We don't respect the numbers of listeners at the moment anyway (i.e., removing one of many will still stop serial).