### PR TITLE
Attempt connection multiple times, retrieve latest services before starting notifications

### DIFF
--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -208,9 +208,7 @@ export class BluetoothDeviceWrapper implements Logging {
       try {
         // Fail immediately if disconnect occurs whilst connecting.
         await this.raceDisconnectAndTimeout(
-          BleClient.connect(this.device.deviceId, this.handleDisconnectEvent, {
-            timeout: connectTimeoutInMs,
-          }),
+          BleClient.connect(this.device.deviceId, this.handleDisconnectEvent),
           {
             actionName: "connect internal",
             timeout: connectTimeoutInMs,
@@ -533,6 +531,7 @@ export class BluetoothDeviceWrapper implements Logging {
         justBonded = true;
       }
       await this.connectInternal();
+
       return justBonded;
     } else {
       // Long timeout as this is the point that the pairing dialog will show.

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -36,8 +36,9 @@ import {
 import { UARTService } from "./uart-service.js";
 
 export const bondingTimeoutInMs = 40_000;
-export const connectTimeoutInMs = 10_000;
+export const connectTimeoutInMs = 4_000;
 export const scanningTimeoutInMs = 10_000;
+const connectionMaxAttempts = 4;
 
 export const isAndroid = () => Capacitor.getPlatform() === "android";
 
@@ -199,10 +200,35 @@ export class BluetoothDeviceWrapper implements Logging {
 
   private async connectInternal() {
     this.waitingForDisconnectEventCallbacks.length = 0;
-    await BleClient.connect(this.device.deviceId, this.handleDisconnectEvent, {
+
+    // Attempt multiple connection tries.
+    for (let i = 0; i < connectionMaxAttempts; i++) {
+      try {
+        // Fail immediately if disconnect occurs whilst connecting.
+        await this.raceDisconnectAndTimeout(
+          BleClient.connect(this.device.deviceId, this.handleDisconnectEvent, {
+            timeout: connectTimeoutInMs,
+          }),
+          {
+            actionName: "connect internal",
       timeout: connectTimeoutInMs,
-    });
+            initiallyDisconnected: true,
+          },
+        );
     this.connected = true;
+        return;
+      } catch (error) {
+        const attempts = i + 1;
+        if (attempts === connectionMaxAttempts) {
+          throw error;
+        }
+        const delayDuration = Math.pow(2, i) * 1000; // 1s, 2s, 4s
+        console.log(
+          `Attempt ${attempts} failed, retrying in ${delayDuration}ms...`,
+        );
+        await delay(delayDuration);
+      }
+    }
   }
 
   async disconnect(): Promise<void> {
@@ -504,25 +530,7 @@ export class BluetoothDeviceWrapper implements Logging {
         await BleClient.createBond(deviceId, { timeout: bondingTimeoutInMs });
         justBonded = true;
       }
-
-      // Connection after flashing fails. Subsequent attempt succeeds.
-      const maxAttempts = 2;
-      for (let i = 0; i < maxAttempts; i++) {
-        try {
-          // Fail immediately if disconnect occurs whilst connecting.
-          await this.raceDisconnectAndTimeout(this.connectInternal(), {
-            actionName: "bond connect device internal",
-            timeout: connectTimeoutInMs,
-            initiallyDisconnected: true,
-          });
-        } catch (error) {
-          const numAttempts = i + 1;
-          if (numAttempts === maxAttempts) {
-            throw error;
-          }
-          console.log(`Attempt ${numAttempts} failed, retry...`);
-        }
-      }
+      await this.connectInternal();
       return justBonded;
     } else {
       // Long timeout as this is the point that the pairing dialog will show.

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -159,6 +159,9 @@ export class BluetoothDeviceWrapper implements Logging {
       await this.getBoardVersion();
 
       const events = this.currentEvents();
+
+      // Ensure services is ready for starting notifications.
+      await delay(1000);
       const services = await BleClient.getServices(this.device.deviceId);
       this.serviceIds = new Set(services.map((s) => s.uuid));
       this.logging.log(`Starting notifications for current events ${events}`);
@@ -211,11 +214,11 @@ export class BluetoothDeviceWrapper implements Logging {
           }),
           {
             actionName: "connect internal",
-      timeout: connectTimeoutInMs,
+            timeout: connectTimeoutInMs,
             initiallyDisconnected: true,
           },
         );
-    this.connected = true;
+        this.connected = true;
         return;
       } catch (error) {
         const attempts = i + 1;

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -223,7 +223,7 @@ export class BluetoothDeviceWrapper implements Logging {
           throw error;
         }
         const delayDuration = Math.pow(2, i) * 1000; // 1s, 2s, 4s
-        console.log(
+        this.logging.log(
           `Attempt ${attempts} failed, retrying in ${delayDuration}ms...`,
         );
         await delay(delayDuration);

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -160,8 +160,7 @@ export class BluetoothDeviceWrapper implements Logging {
 
       const events = this.currentEvents();
 
-      // Ensure services is ready for starting notifications.
-      await delay(1000);
+      await BleClient.discoverServices(this.device.deviceId);
       const services = await BleClient.getServices(this.device.deviceId);
       this.serviceIds = new Set(services.map((s) => s.uuid));
       this.logging.log(`Starting notifications for current events ${events}`);

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -409,9 +409,10 @@ export class BluetoothDeviceWrapper implements Logging {
     options: {
       actionName?: string;
       timeout?: number;
+      initiallyDisconnected?: boolean;
     } = {},
   ): Promise<T> {
-    if (!this.connected) {
+    if (!this.connected && !options.initiallyDisconnected) {
       throw new DisconnectError();
     }
     const actionName = options.actionName ?? "action";
@@ -503,8 +504,25 @@ export class BluetoothDeviceWrapper implements Logging {
         await BleClient.createBond(deviceId, { timeout: bondingTimeoutInMs });
         justBonded = true;
       }
-      await this.connectInternal();
 
+      // Connection after flashing fails. Subsequent attempt succeeds.
+      const maxAttempts = 2;
+      for (let i = 0; i < maxAttempts; i++) {
+        try {
+          // Fail immediately if disconnect occurs whilst connecting.
+          await this.raceDisconnectAndTimeout(this.connectInternal(), {
+            actionName: "bond connect device internal",
+            timeout: connectTimeoutInMs,
+            initiallyDisconnected: true,
+          });
+        } catch (error) {
+          const numAttempts = i + 1;
+          if (numAttempts === maxAttempts) {
+            throw error;
+          }
+          console.log(`Attempt ${numAttempts} failed, retry...`);
+        }
+      }
       return justBonded;
     } else {
       // Long timeout as this is the point that the pairing dialog will show.


### PR DESCRIPTION
- Attempt to connect four times before throwing error.
- Throw immediately if disconnect occurs whilst connecting instead of waiting for timeout.
- Ensure latest services are found.