### PR TITLE
Skip internal connection attempts if reconnecting

### DIFF
--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -201,8 +201,12 @@ export class BluetoothDeviceWrapper implements Logging {
   private async connectInternal() {
     this.waitingForDisconnectEventCallbacks.length = 0;
 
-    // Attempt multiple connection tries.
-    for (let i = 0; i < connectionMaxAttempts; i++) {
+    // Attempt multiple connection tries if not reconnecting.
+    if (this.isReconnect) {
+      this.logging.log("Reconnect - skipping internal connection attempts")
+    }
+    const maxAttempts = this.isReconnect ? 1 : connectionMaxAttempts;
+    for (let i = 0; i < maxAttempts; i++) {
       try {
         // Fail immediately if disconnect occurs whilst connecting.
         await this.raceDisconnectAndTimeout(
@@ -217,7 +221,7 @@ export class BluetoothDeviceWrapper implements Logging {
         return;
       } catch (error) {
         const attempts = i + 1;
-        if (attempts === connectionMaxAttempts) {
+        if (attempts === maxAttempts) {
           throw error;
         }
         const delayDuration = Math.pow(2, i) * 1000; // 1s, 2s, 4s

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -203,7 +203,7 @@ export class BluetoothDeviceWrapper implements Logging {
 
     // Attempt multiple connection tries if not reconnecting.
     if (this.isReconnect) {
-      this.logging.log("Reconnect - skipping internal connection attempts")
+      this.logging.log("Reconnect - skipping internal connection attempts");
     }
     const maxAttempts = this.isReconnect ? 1 : connectionMaxAttempts;
     for (let i = 0; i < maxAttempts; i++) {


### PR DESCRIPTION
We already automatically try reconnecting when handling disconnect event (see [here](https://github.com/microbit-foundation/microbit-connection/blob/shorter-reconnect/lib/bluetooth-device-wrapper.ts#L273)) so we don't need to have the extra layer of retries.