### PR TITLE
Add aborting device scanning method, error type, and progress stages

### DIFF
--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -20,7 +20,7 @@ import {
 } from "./async-util.js";
 import { ButtonService } from "./button-service.js";
 import { DeviceInformationService } from "./device-information-service.js";
-import { BoardVersion, DeviceError } from "./device.js";
+import { BoardVersion, ConnectOptions, DeviceError, ProgressCallback, ProgressStage } from "./device.js";
 import { LedService } from "./led-service.js";
 import { Logging, LoggingEvent, ConsoleLogging } from "./logging.js";
 import { MagnetometerService } from "./magnetometer-service.js";
@@ -136,7 +136,8 @@ export class BluetoothDeviceWrapper implements Logging {
     ];
   }
 
-  async connect(): Promise<void> {
+  async connect(options?: ConnectOptions): Promise<void> {
+    const progress = options?.progress ?? (() => {});
     this.logging.event({
       type: this.isReconnect ? "Reconnect" : "Connect",
       message: "Bluetooth connect start",
@@ -151,10 +152,11 @@ export class BluetoothDeviceWrapper implements Logging {
 
     try {
       if (Capacitor.isNativePlatform()) {
-        await this.connectHandlingBond();
+        await this.connectHandlingBond(progress);
         // We need this on Android for reconnecting after DFU.
         await BleClient.discoverServices(this.device.deviceId);
       } else {
+        progress(ProgressStage.Connecting)
         await this.connectInternal();
       }
       await this.getBoardVersion();
@@ -465,7 +467,8 @@ export class BluetoothDeviceWrapper implements Logging {
    * Bonds with device and handles the post-bond device state only returning
    * when we can reattempt a connection with the device.
    */
-  private async connectHandlingBond(): Promise<void> {
+  private async connectHandlingBond(progress: ProgressCallback): Promise<void> {
+    progress(ProgressStage.CheckingBond)
     const startTime = Date.now();
     const maybeJustBonded = await this.bondConnectDeviceInternal();
     if (maybeJustBonded) {
@@ -496,10 +499,14 @@ export class BluetoothDeviceWrapper implements Logging {
       await this.connectInternal();
       // TODO: check this is needed, potentially inline into connect if always needed
       await delay(500);
+
+      progress(ProgressStage.ResettingDevice);
       this.log("Resetting to pairing mode");
       const pf = new PartialFlashingService(this);
       await pf.resetToMode(MicroBitMode.Pairing);
       await this.waitForDisconnect(10_000);
+
+      progress(ProgressStage.Connecting);
       await this.connectInternal();
       this.log(`Connection ready; took ${Date.now() - startTime}`);
     }

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -197,6 +197,7 @@ export class BluetoothDeviceWrapper implements Logging {
         });
       }
       if (
+        // Error thrown in iOS only.
         e instanceof Error &&
         e.message === "Peer removed pairing information"
       ) {

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -20,7 +20,13 @@ import {
 } from "./async-util.js";
 import { ButtonService } from "./button-service.js";
 import { DeviceInformationService } from "./device-information-service.js";
-import { BoardVersion, ConnectOptions, DeviceError, ProgressCallback, ProgressStage } from "./device.js";
+import {
+  BoardVersion,
+  ConnectOptions,
+  DeviceError,
+  ProgressCallback,
+  ProgressStage,
+} from "./device.js";
 import { LedService } from "./led-service.js";
 import { Logging, LoggingEvent, ConsoleLogging } from "./logging.js";
 import { MagnetometerService } from "./magnetometer-service.js";
@@ -156,7 +162,7 @@ export class BluetoothDeviceWrapper implements Logging {
         // We need this on Android for reconnecting after DFU.
         await BleClient.discoverServices(this.device.deviceId);
       } else {
-        progress(ProgressStage.Connecting)
+        progress(ProgressStage.Connecting);
         await this.connectInternal();
       }
       await this.getBoardVersion();
@@ -468,7 +474,7 @@ export class BluetoothDeviceWrapper implements Logging {
    * when we can reattempt a connection with the device.
    */
   private async connectHandlingBond(progress: ProgressCallback): Promise<void> {
-    progress(ProgressStage.CheckingBond)
+    progress(ProgressStage.CheckingBond);
     const startTime = Date.now();
     const maybeJustBonded = await this.bondConnectDeviceInternal();
     if (maybeJustBonded) {

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -188,6 +188,15 @@ export class BluetoothDeviceWrapper implements Logging {
           message: e instanceof Error ? e.message : String(e),
         });
       }
+      if (
+        e instanceof Error &&
+        e.message === "Peer removed pairing information"
+      ) {
+        throw new DeviceError({
+          code: "pairing-information-lost",
+          message: e.message,
+        });
+      }
       throw new DeviceError({
         code: "bluetooth-connection-failed",
         message: e instanceof Error ? e.message : String(e),

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -580,7 +580,7 @@ class MicrobitWebBluetoothConnectionImpl
   }
 
   private hasAbortedDeviceScan: boolean = false;
-  private abortScanPromiseResolve: undefined | (() => Promise<undefined>);
+  private abortScanPromiseResolve: undefined | (() => void);
 
   /**
    * Finds device with specified name prefix.
@@ -620,10 +620,8 @@ class MicrobitWebBluetoothConnectionImpl
         }),
     );
     const abortScanPromise: Promise<undefined> = new Promise((resolve) => {
-      this.abortScanPromiseResolve = async () => {
-        this.hasAbortedDeviceScan = true;
-        await BleClient.stopLEScan();
-        this.log("Abort scanning for devices");
+      this.abortScanPromiseResolve = () => {
+        this.abortScanPromiseResolve = undefined;
         resolve(undefined);
       };
     });
@@ -633,6 +631,7 @@ class MicrobitWebBluetoothConnectionImpl
           await BleClient.stopLEScan();
           this.log("Timeout scanning for device");
           resolve(undefined);
+          this.abortScanPromiseResolve && this.abortScanPromiseResolve();
         }
       }, scanningTimeoutInMs),
     );
@@ -644,8 +643,11 @@ class MicrobitWebBluetoothConnectionImpl
   }
 
   async abortDeviceScan() {
-    if (Capacitor.isNativePlatform()) {
-      this.abortScanPromiseResolve && (await this.abortScanPromiseResolve());
+    if (Capacitor.isNativePlatform() && this.abortScanPromiseResolve) {
+      this.hasAbortedDeviceScan = true;
+      await BleClient.stopLEScan();
+      this.log("Abort scanning for devices");
+      this.abortScanPromiseResolve();
     }
   }
 

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -167,6 +167,11 @@ export interface MicrobitWebBluetoothConnection
    * @throws {FlashDataError} If data preparation fails.
    */
   flash(dataSource: FlashDataSource, options: FlashOptions): Promise<void>;
+
+  /**
+   * Stops device scanning.
+   */
+  abortDeviceScan(): Promise<void>;
 }
 
 /**
@@ -575,6 +580,9 @@ class MicrobitWebBluetoothConnectionImpl
     }
   }
 
+  private hasAbortedDeviceScan: boolean = false;
+  private abortScanPromiseResolve: undefined | (() => Promise<undefined>);
+
   /**
    * Finds device with specified name prefix.
    *
@@ -591,8 +599,8 @@ class MicrobitWebBluetoothConnectionImpl
     if (bonded) {
       return bonded;
     }
-
     this.log(`Scanning for device - ${namePrefix}`);
+    this.hasAbortedDeviceScan = false;
     let found = false;
     const scanPromise: Promise<BleDevice> = new Promise(
       (resolve) =>
@@ -612,16 +620,34 @@ class MicrobitWebBluetoothConnectionImpl
           }
         }),
     );
+    const abortScanPromise: Promise<undefined> = new Promise((resolve) => {
+      this.abortScanPromiseResolve = async () => {
+        this.hasAbortedDeviceScan = true;
+        await BleClient.stopLEScan();
+        this.log("Abort scanning for devices");
+        resolve(undefined);
+      };
+    });
     const scanTimeoutPromise: Promise<undefined> = new Promise((resolve) =>
       setTimeout(async () => {
-        if (!found) {
+        if (!found && !this.hasAbortedDeviceScan) {
           await BleClient.stopLEScan();
           this.log("Timeout scanning for device");
           resolve(undefined);
         }
       }, scanningTimeoutInMs),
     );
-    return await Promise.race([scanPromise, scanTimeoutPromise]);
+    return await Promise.race([
+      scanPromise,
+      scanTimeoutPromise,
+      abortScanPromise,
+    ]);
+  }
+
+  async abortDeviceScan() {
+    if (Capacitor.isNativePlatform()) {
+      this.abortScanPromiseResolve && (await this.abortScanPromiseResolve());
+    }
   }
 
   private async checkBondedDevices(predicate: (device: BleDevice) => boolean) {

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -325,8 +325,7 @@ class MicrobitWebBluetoothConnectionImpl
       );
     }
 
-    progress(ProgressStage.Connecting);
-    await this.connection.connect();
+    await this.connection.connect(options);
   }
 
   async disconnect(): Promise<void> {

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -96,10 +96,33 @@ export type DeviceErrorCode =
   | "location-disabled";
 
 export enum ProgressStage {
+  /**
+   * Checking permissions and availability before connecting.
+   */
   Initializing = "Initializing",
+  /**
+   * Finding device.
+   */
   FindingDevice = "FindingDevice",
+  /**
+   * Checking that a bond is established. Only applicable on Native platforms.
+   */
+  CheckingBond = "CheckingBond",
+  /**
+   * Resetting device in preparation for flashing. Only applicable on Native platforms.
+   */
+  ResettingDevice = "ResettingDevice",
+  /**
+   * Connecting for flashing.
+   */
   Connecting = "Connecting",
+  /**
+   * Partial flashing.
+   */
   PartialFlashing = "PartialFlashing",
+  /**
+   * Full flashing.
+   */
   FullFlashing = "FullFlashing",
 }
 
@@ -108,7 +131,8 @@ export enum ProgressStage {
  *
  * @param stage - The current stage of the operation
  * @param progress - Optional progress value (0-1) for PartialFlashing and FullFlashing stages.
- *                   Initializing, FindingDevice, and Connecting stages are called once
+ *                   Initializing, FindingDevice, CheckingBond (only for native platforms),
+ *                   ResettingDevice (only for native platforms), and Connecting stages are called once
  *                   without progress values to indicate stage entry.
  *
  * @example

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -59,6 +59,10 @@ export type DeviceErrorCode =
    */
   | "bluetooth-connection-failed"
   /**
+   * Pairing information lost on micro:bit.
+   */
+  | "pairing-information-lost"
+  /**
    * Partial flash operation failed.
    */
   | "flash-partial-failed"


### PR DESCRIPTION
- Add a new error code for pairing information lost on peripheral.
- Add new native-only progress stages (`ProgressStage.CheckingBond` and `ProgressStage.ResettingDevice`).
- Add abort device scan method to allow for stopping of scanning.