### PR TITLE
Add ability to abort connect, new error type, and progress stages

### DIFF
--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -20,7 +20,7 @@ import {
 } from "./async-util.js";
 import { ButtonService } from "./button-service.js";
 import { DeviceInformationService } from "./device-information-service.js";
-import { BoardVersion, DeviceError } from "./device.js";
+import { BoardVersion, ConnectOptions, DeviceError, ProgressCallback, ProgressStage } from "./device.js";
 import { LedService } from "./led-service.js";
 import { Logging, LoggingEvent, ConsoleLogging } from "./logging.js";
 import { MagnetometerService } from "./magnetometer-service.js";
@@ -136,7 +136,8 @@ export class BluetoothDeviceWrapper implements Logging {
     ];
   }
 
-  async connect(): Promise<void> {
+  async connect(options?: ConnectOptions): Promise<void> {
+    const progress = options?.progress ?? (() => {});
     this.logging.event({
       type: this.isReconnect ? "Reconnect" : "Connect",
       message: "Bluetooth connect start",
@@ -151,10 +152,11 @@ export class BluetoothDeviceWrapper implements Logging {
 
     try {
       if (Capacitor.isNativePlatform()) {
-        await this.connectHandlingBond();
+        await this.connectHandlingBond(progress);
         // We need this on Android for reconnecting after DFU.
         await BleClient.discoverServices(this.device.deviceId);
       } else {
+        progress(ProgressStage.Connecting)
         await this.connectInternal();
       }
       await this.getBoardVersion();
@@ -465,7 +467,8 @@ export class BluetoothDeviceWrapper implements Logging {
    * Bonds with device and handles the post-bond device state only returning
    * when we can reattempt a connection with the device.
    */
-  private async connectHandlingBond(): Promise<void> {
+  private async connectHandlingBond(progress: ProgressCallback): Promise<void> {
+    progress(ProgressStage.CheckingBond)
     const startTime = Date.now();
     const maybeJustBonded = await this.bondConnectDeviceInternal();
     if (maybeJustBonded) {
@@ -496,10 +499,14 @@ export class BluetoothDeviceWrapper implements Logging {
       await this.connectInternal();
       // TODO: check this is needed, potentially inline into connect if always needed
       await delay(500);
+
+      progress(ProgressStage.ResettingDevice);
       this.log("Resetting to pairing mode");
       const pf = new PartialFlashingService(this);
       await pf.resetToMode(MicroBitMode.Pairing);
       await this.waitForDisconnect(10_000);
+
+      progress(ProgressStage.Connecting);
       await this.connectInternal();
       this.log(`Connection ready; took ${Date.now() - startTime}`);
     }

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -197,6 +197,7 @@ export class BluetoothDeviceWrapper implements Logging {
         });
       }
       if (
+        // Error thrown in iOS only.
         e instanceof Error &&
         e.message === "Peer removed pairing information"
       ) {

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -20,7 +20,13 @@ import {
 } from "./async-util.js";
 import { ButtonService } from "./button-service.js";
 import { DeviceInformationService } from "./device-information-service.js";
-import { BoardVersion, ConnectOptions, DeviceError, ProgressCallback, ProgressStage } from "./device.js";
+import {
+  BoardVersion,
+  ConnectOptions,
+  DeviceError,
+  ProgressCallback,
+  ProgressStage,
+} from "./device.js";
 import { LedService } from "./led-service.js";
 import { Logging, LoggingEvent, ConsoleLogging } from "./logging.js";
 import { MagnetometerService } from "./magnetometer-service.js";
@@ -156,7 +162,7 @@ export class BluetoothDeviceWrapper implements Logging {
         // We need this on Android for reconnecting after DFU.
         await BleClient.discoverServices(this.device.deviceId);
       } else {
-        progress(ProgressStage.Connecting)
+        progress(ProgressStage.Connecting);
         await this.connectInternal();
       }
       await this.getBoardVersion();
@@ -468,7 +474,7 @@ export class BluetoothDeviceWrapper implements Logging {
    * when we can reattempt a connection with the device.
    */
   private async connectHandlingBond(progress: ProgressCallback): Promise<void> {
-    progress(ProgressStage.CheckingBond)
+    progress(ProgressStage.CheckingBond);
     const startTime = Date.now();
     const maybeJustBonded = await this.bondConnectDeviceInternal();
     if (maybeJustBonded) {

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -188,6 +188,15 @@ export class BluetoothDeviceWrapper implements Logging {
           message: e instanceof Error ? e.message : String(e),
         });
       }
+      if (
+        e instanceof Error &&
+        e.message === "Peer removed pairing information"
+      ) {
+        throw new DeviceError({
+          code: "pairing-information-lost",
+          message: e.message,
+        });
+      }
       throw new DeviceError({
         code: "bluetooth-connection-failed",
         message: e instanceof Error ? e.message : String(e),

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -580,7 +580,7 @@ class MicrobitWebBluetoothConnectionImpl
   }
 
   private hasAbortedDeviceScan: boolean = false;
-  private abortScanPromiseResolve: undefined | (() => Promise<undefined>);
+  private abortScanPromiseResolve: undefined | (() => void);
 
   /**
    * Finds device with specified name prefix.
@@ -620,10 +620,8 @@ class MicrobitWebBluetoothConnectionImpl
         }),
     );
     const abortScanPromise: Promise<undefined> = new Promise((resolve) => {
-      this.abortScanPromiseResolve = async () => {
-        this.hasAbortedDeviceScan = true;
-        await BleClient.stopLEScan();
-        this.log("Abort scanning for devices");
+      this.abortScanPromiseResolve = () => {
+        this.abortScanPromiseResolve = undefined;
         resolve(undefined);
       };
     });
@@ -633,6 +631,7 @@ class MicrobitWebBluetoothConnectionImpl
           await BleClient.stopLEScan();
           this.log("Timeout scanning for device");
           resolve(undefined);
+          this.abortScanPromiseResolve && this.abortScanPromiseResolve();
         }
       }, scanningTimeoutInMs),
     );
@@ -644,8 +643,11 @@ class MicrobitWebBluetoothConnectionImpl
   }
 
   async abortDeviceScan() {
-    if (Capacitor.isNativePlatform()) {
-      this.abortScanPromiseResolve && (await this.abortScanPromiseResolve());
+    if (Capacitor.isNativePlatform() && this.abortScanPromiseResolve) {
+      this.hasAbortedDeviceScan = true;
+      await BleClient.stopLEScan();
+      this.log("Abort scanning for devices");
+      this.abortScanPromiseResolve();
     }
   }
 

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -167,6 +167,11 @@ export interface MicrobitWebBluetoothConnection
    * @throws {FlashDataError} If data preparation fails.
    */
   flash(dataSource: FlashDataSource, options: FlashOptions): Promise<void>;
+
+  /**
+   * Stops device scanning.
+   */
+  abortDeviceScan(): Promise<void>;
 }
 
 /**
@@ -575,6 +580,9 @@ class MicrobitWebBluetoothConnectionImpl
     }
   }
 
+  private hasAbortedDeviceScan: boolean = false;
+  private abortScanPromiseResolve: undefined | (() => Promise<undefined>);
+
   /**
    * Finds device with specified name prefix.
    *
@@ -591,8 +599,8 @@ class MicrobitWebBluetoothConnectionImpl
     if (bonded) {
       return bonded;
     }
-
     this.log(`Scanning for device - ${namePrefix}`);
+    this.hasAbortedDeviceScan = false;
     let found = false;
     const scanPromise: Promise<BleDevice> = new Promise(
       (resolve) =>
@@ -612,16 +620,34 @@ class MicrobitWebBluetoothConnectionImpl
           }
         }),
     );
+    const abortScanPromise: Promise<undefined> = new Promise((resolve) => {
+      this.abortScanPromiseResolve = async () => {
+        this.hasAbortedDeviceScan = true;
+        await BleClient.stopLEScan();
+        this.log("Abort scanning for devices");
+        resolve(undefined);
+      };
+    });
     const scanTimeoutPromise: Promise<undefined> = new Promise((resolve) =>
       setTimeout(async () => {
-        if (!found) {
+        if (!found && !this.hasAbortedDeviceScan) {
           await BleClient.stopLEScan();
           this.log("Timeout scanning for device");
           resolve(undefined);
         }
       }, scanningTimeoutInMs),
     );
-    return await Promise.race([scanPromise, scanTimeoutPromise]);
+    return await Promise.race([
+      scanPromise,
+      scanTimeoutPromise,
+      abortScanPromise,
+    ]);
+  }
+
+  async abortDeviceScan() {
+    if (Capacitor.isNativePlatform()) {
+      this.abortScanPromiseResolve && (await this.abortScanPromiseResolve());
+    }
   }
 
   private async checkBondedDevices(predicate: (device: BleDevice) => boolean) {

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -624,7 +624,9 @@ class MicrobitWebBluetoothConnectionImpl
           aborted = true;
           await BleClient.stopLEScan();
           this.log("Abort scanning for devices");
-          reject(new DeviceError({ code: "aborted", message: "Connection aborted" }));
+          reject(
+            new DeviceError({ code: "aborted", message: "Connection aborted" }),
+          );
         },
         { once: true },
       );

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -578,14 +578,14 @@ class MicrobitWebBluetoothConnectionImpl
    * Finds device with specified name prefix.
    *
    * @returns device or undefined if none can be found.
-   * @throws DeviceError with code "cancelled" if signal is aborted.
+   * @throws DeviceError with code "aborted" if signal is aborted.
    */
   private async requestDeviceNative(
     namePrefix: string,
     signal?: AbortSignal,
   ): Promise<BleDevice | undefined> {
     if (signal?.aborted) {
-      throw new DeviceError({ code: "cancelled", message: "Connection aborted" });
+      throw new DeviceError({ code: "aborted", message: "Connection aborted" });
     }
 
     // Check for existing bonded devices.
@@ -624,7 +624,7 @@ class MicrobitWebBluetoothConnectionImpl
           aborted = true;
           await BleClient.stopLEScan();
           this.log("Abort scanning for devices");
-          reject(new DeviceError({ code: "cancelled", message: "Connection aborted" }));
+          reject(new DeviceError({ code: "aborted", message: "Connection aborted" }));
         },
         { once: true },
       );

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -325,8 +325,7 @@ class MicrobitWebBluetoothConnectionImpl
       );
     }
 
-    progress(ProgressStage.Connecting);
-    await this.connection.connect();
+    await this.connection.connect(options);
   }
 
   async disconnect(): Promise<void> {

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -167,11 +167,6 @@ export interface MicrobitWebBluetoothConnection
    * @throws {FlashDataError} If data preparation fails.
    */
   flash(dataSource: FlashDataSource, options: FlashOptions): Promise<void>;
-
-  /**
-   * Stops device scanning.
-   */
-  abortDeviceScan(): Promise<void>;
 }
 
 /**
@@ -307,7 +302,7 @@ class MicrobitWebBluetoothConnectionImpl
 
     if (!this.connection) {
       progress(ProgressStage.FindingDevice);
-      const device = await this.requestDevice();
+      const device = await this.requestDevice(options?.signal);
       this.connection = new BluetoothDeviceWrapper(
         device,
         this.logging,
@@ -377,7 +372,7 @@ class MicrobitWebBluetoothConnectionImpl
     this.nameFilter = name;
   }
 
-  private async requestDevice(): Promise<BleDevice> {
+  private async requestDevice(signal?: AbortSignal): Promise<BleDevice> {
     // TODO: is this possible to reinstate?
     // See https://github.com/bsiever/microbit-pxt-blehid/issues/31
     // namePrefix: this.nameFilter
@@ -402,7 +397,7 @@ class MicrobitWebBluetoothConnectionImpl
     this.dispatchTypedEvent("beforerequestdevice", new BeforeRequestDevice());
     try {
       this.device = Capacitor.isNativePlatform()
-        ? await this.requestDeviceNative(namePrefix)
+        ? await this.requestDeviceNative(namePrefix, signal)
         : await this.requestDeviceWeb(namePrefix);
       if (!this.device) {
         this.setStatus(ConnectionStatus.NO_AUTHORIZED_DEVICE);
@@ -491,7 +486,7 @@ class MicrobitWebBluetoothConnectionImpl
       this.deferredUpdatesPreviousStatus = this.status;
 
       if (this.status !== ConnectionStatus.CONNECTED) {
-        await this.connect({ progress });
+        await this.connect({ progress, signal: options.signal });
       }
 
       const connection = this.connection!;
@@ -579,17 +574,20 @@ class MicrobitWebBluetoothConnectionImpl
     }
   }
 
-  private hasAbortedDeviceScan: boolean = false;
-  private abortScanPromiseResolve: undefined | (() => void);
-
   /**
    * Finds device with specified name prefix.
    *
    * @returns device or undefined if none can be found.
+   * @throws DeviceError with code "cancelled" if signal is aborted.
    */
   private async requestDeviceNative(
     namePrefix: string,
+    signal?: AbortSignal,
   ): Promise<BleDevice | undefined> {
+    if (signal?.aborted) {
+      throw new DeviceError({ code: "cancelled", message: "Connection aborted" });
+    }
+
     // Check for existing bonded devices.
     const bonded = await this.checkBondedDevices((device: BleDevice) => {
       const name = device.name;
@@ -599,8 +597,8 @@ class MicrobitWebBluetoothConnectionImpl
       return bonded;
     }
     this.log(`Scanning for device - ${namePrefix}`);
-    this.hasAbortedDeviceScan = false;
     let found = false;
+    let aborted = false;
     const scanPromise: Promise<BleDevice> = new Promise(
       (resolve) =>
         // This only resolves when we stop the scan.
@@ -619,36 +617,28 @@ class MicrobitWebBluetoothConnectionImpl
           }
         }),
     );
-    const abortScanPromise: Promise<undefined> = new Promise((resolve) => {
-      this.abortScanPromiseResolve = () => {
-        this.abortScanPromiseResolve = undefined;
-        resolve(undefined);
-      };
+    const abortPromise = new Promise<never>((_, reject) => {
+      signal?.addEventListener(
+        "abort",
+        async () => {
+          aborted = true;
+          await BleClient.stopLEScan();
+          this.log("Abort scanning for devices");
+          reject(new DeviceError({ code: "cancelled", message: "Connection aborted" }));
+        },
+        { once: true },
+      );
     });
     const scanTimeoutPromise: Promise<undefined> = new Promise((resolve) =>
       setTimeout(async () => {
-        if (!found && !this.hasAbortedDeviceScan) {
+        if (!found && !aborted) {
           await BleClient.stopLEScan();
           this.log("Timeout scanning for device");
           resolve(undefined);
-          this.abortScanPromiseResolve && this.abortScanPromiseResolve();
         }
       }, scanningTimeoutInMs),
     );
-    return await Promise.race([
-      scanPromise,
-      scanTimeoutPromise,
-      abortScanPromise,
-    ]);
-  }
-
-  async abortDeviceScan() {
-    if (Capacitor.isNativePlatform() && this.abortScanPromiseResolve) {
-      this.hasAbortedDeviceScan = true;
-      await BleClient.stopLEScan();
-      this.log("Abort scanning for devices");
-      this.abortScanPromiseResolve();
-    }
+    return await Promise.race([scanPromise, scanTimeoutPromise, abortPromise]);
   }
 
   private async checkBondedDevices(predicate: (device: BleDevice) => boolean) {

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -23,6 +23,10 @@ export type ConnectionAvailabilityStatus =
  */
 export type DeviceErrorCode =
   /**
+   * Operation was cancelled via an AbortSignal.
+   */
+  | "cancelled"
+  /**
    * Device not selected, e.g. because the user cancelled the dialog.
    */
   | "no-device-selected"
@@ -210,6 +214,16 @@ export interface ConnectOptions {
    * Optional progress callback for tracking connection stages.
    */
   progress?: ProgressCallback;
+  /**
+   * Optional AbortSignal to cancel the connection attempt.
+   * When aborted, the connect promise will reject with a DeviceError
+   * with code "cancelled".
+   *
+   * Note: Currently only cancels during the FindingDevice stage on native
+   * platforms. Web platform device selection (browser picker) cannot be
+   * cancelled programmatically.
+   */
+  signal?: AbortSignal;
 }
 
 export interface FlashOptions {
@@ -230,6 +244,16 @@ export interface FlashOptions {
    * Smallest possible progress increment to limit callback rate.
    */
   minimumProgressIncrement?: number;
+  /**
+   * Optional AbortSignal to cancel the flash operation.
+   * When aborted, the flash promise will reject with a DeviceError
+   * with code "cancelled".
+   *
+   * Note: Currently only cancels during the FindingDevice stage on native
+   * platforms. Once a device is found and flashing begins, the operation
+   * cannot be cancelled.
+   */
+  signal?: AbortSignal;
 }
 
 export class FlashDataError extends Error {}
@@ -304,7 +328,7 @@ export interface DeviceConnection<M extends ValueIsEvent<M>>
   /**
    * Connects to a currently paired device or requests pairing.
    *
-   * @param options Optional connection options including progress callback.
+   * @param options Optional connection options including progress callback and abort signal.
    * @throws {DeviceError} On connection failure. The error.code property indicates the failure type.
    */
   connect(options?: ConnectOptions): Promise<void>;

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -96,10 +96,33 @@ export type DeviceErrorCode =
   | "location-disabled";
 
 export enum ProgressStage {
+  /**
+   * Checking permissions and availability before connecting.
+   */
   Initializing = "Initializing",
+  /**
+   * Finding device.
+   */
   FindingDevice = "FindingDevice",
+  /**
+   * Checking that a bond is established. Only applicable on Native platforms.
+   */
+  CheckingBond = "CheckingBond",
+  /**
+   * Resetting device in preparation for flashing. Only applicable on Native platforms.
+   */
+  ResettingDevice = "ResettingDevice",
+  /**
+   * Connecting for flashing.
+   */
   Connecting = "Connecting",
+  /**
+   * Partial flashing.
+   */
   PartialFlashing = "PartialFlashing",
+  /**
+   * Full flashing.
+   */
   FullFlashing = "FullFlashing",
 }
 
@@ -108,7 +131,8 @@ export enum ProgressStage {
  *
  * @param stage - The current stage of the operation
  * @param progress - Optional progress value (0-1) for PartialFlashing and FullFlashing stages.
- *                   Initializing, FindingDevice, and Connecting stages are called once
+ *                   Initializing, FindingDevice, CheckingBond (only for native platforms),
+ *                   ResettingDevice (only for native platforms), and Connecting stages are called once
  *                   without progress values to indicate stage entry.
  *
  * @example

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -59,6 +59,10 @@ export type DeviceErrorCode =
    */
   | "bluetooth-connection-failed"
   /**
+   * Pairing information lost on micro:bit.
+   */
+  | "pairing-information-lost"
+  /**
    * Partial flash operation failed.
    */
   | "flash-partial-failed"

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -23,9 +23,9 @@ export type ConnectionAvailabilityStatus =
  */
 export type DeviceErrorCode =
   /**
-   * Operation was cancelled via an AbortSignal.
+   * Operation was aborted via an AbortSignal.
    */
-  | "cancelled"
+  | "aborted"
   /**
    * Device not selected, e.g. because the user cancelled the dialog.
    */
@@ -215,13 +215,13 @@ export interface ConnectOptions {
    */
   progress?: ProgressCallback;
   /**
-   * Optional AbortSignal to cancel the connection attempt.
+   * Optional AbortSignal to abort the connection attempt.
    * When aborted, the connect promise will reject with a DeviceError
-   * with code "cancelled".
+   * with code "aborted".
    *
-   * Note: Currently only cancels during the FindingDevice stage on native
+   * Note: Currently only aborts during the FindingDevice stage on native
    * platforms. Web platform device selection (browser picker) cannot be
-   * cancelled programmatically.
+   * aborted programmatically.
    */
   signal?: AbortSignal;
 }
@@ -245,13 +245,13 @@ export interface FlashOptions {
    */
   minimumProgressIncrement?: number;
   /**
-   * Optional AbortSignal to cancel the flash operation.
+   * Optional AbortSignal to abort the flash operation.
    * When aborted, the flash promise will reject with a DeviceError
-   * with code "cancelled".
+   * with code "aborted".
    *
-   * Note: Currently only cancels during the FindingDevice stage on native
+   * Note: Currently only aborts during the FindingDevice stage on native
    * platforms. Once a device is found and flashing begins, the operation
-   * cannot be cancelled.
+   * cannot be aborted.
    */
   signal?: AbortSignal;
 }


### PR DESCRIPTION
- Add a new error code for pairing information lost on peripheral.
- Add new native-only progress stages (ProgressStage.CheckingBond and ProgressStage.ResettingDevice).
- Add abort signal to allow for stopping of scanning (and potentially other steps in future)

