### PR TITLE
Remove auto reconnect, `ConnectionStatus.Reconnecting`, and discarding of device on disconnect

### DIFF
--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -172,7 +172,7 @@ export class BluetoothDeviceWrapper implements Logging {
         type: "Connect",
         message: "Bluetooth connect failed",
       });
-      await this.disconnectInternal();
+      await this.disconnectInternal(false);
       this.callbacks.onDisconnect();
 
       if (e instanceof DeviceError) {
@@ -210,11 +210,13 @@ export class BluetoothDeviceWrapper implements Logging {
   }
 
   async disconnect(): Promise<void> {
-    return this.disconnectInternal();
+    return this.disconnectInternal(true);
   }
 
-  private async disconnectInternal(): Promise<void> {
-    this.logging.log("Bluetooth disconnect");
+  private async disconnectInternal(userTriggered: boolean): Promise<void> {
+    this.logging.log(
+      `Bluetooth disconnect ${userTriggered ? "(user triggered)" : "(programmatic)"}`,
+    );
     try {
       if (this.connected) {
         await BleClient.disconnect(this.device.deviceId);

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -56,7 +56,7 @@ export interface Service {
 
 interface ConnectCallbacks {
   onConnecting: () => void;
-  onFail: () => void;
+  onDisconnect: (isFail: boolean) => void;
   onSuccess: () => void;
 }
 
@@ -173,7 +173,7 @@ export class BluetoothDeviceWrapper implements Logging {
         message: "Bluetooth connect failed",
       });
       await this.disconnectInternal();
-      this.callbacks.onFail();
+      this.callbacks.onDisconnect(true);
 
       if (e instanceof DeviceError) {
         throw e;
@@ -226,12 +226,16 @@ export class BluetoothDeviceWrapper implements Logging {
   }
 
   handleDisconnectEvent = (): void => {
+    const isExpectedDisconnect =
+      this.waitingForDisconnectEventCallbacks.length > 0;
     this.waitingForDisconnectEventCallbacks.forEach((cb) => cb());
     this.waitingForDisconnectEventCallbacks.length = 0;
 
     this.connected = false;
-    this.logging.log("Bluetooth disconnect");
-    this.callbacks.onFail();
+    this.logging.log(
+      `Bluetooth ${isExpectedDisconnect ? "expected" : "unexpected"} disconnect`,
+    );
+    this.callbacks.onDisconnect(!isExpectedDisconnect);
   };
 
   async getBoardVersion(): Promise<BoardVersion> {

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -56,7 +56,7 @@ export interface Service {
 
 interface ConnectCallbacks {
   onConnecting: () => void;
-  onDisconnect: (isFail: boolean) => void;
+  onDisconnect: (clearConnection: boolean) => void;
   onSuccess: () => void;
 }
 

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -232,7 +232,6 @@ export class BluetoothDeviceWrapper implements Logging {
     this.waitingForDisconnectEventCallbacks.length = 0;
 
     this.connected = false;
-    this.logging.log("Bluetooth disconnect");
     this.callbacks.onDisconnect();
   };
 

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -56,7 +56,6 @@ export interface Service {
 
 interface ConnectCallbacks {
   onConnecting: () => void;
-  onReconnecting: () => void;
   onFail: () => void;
   onSuccess: () => void;
 }
@@ -84,12 +83,7 @@ interface ConnectCallbacks {
 // > this out after 30 seconds and reload the page
 
 export class BluetoothDeviceWrapper implements Logging {
-  // Used to avoid automatic reconnection during user triggered connect/disconnect
-  // or reconnection itself.
-  private duringExplicitConnectDisconnect: number = 0;
-
   connected = false;
-  private isReconnect = false;
 
   // Only updated after the full connection flow completes not during bond handling.
   private serviceIds: Set<string> = new Set();
@@ -145,16 +139,10 @@ export class BluetoothDeviceWrapper implements Logging {
   async connect(options?: ConnectOptions): Promise<void> {
     const progress = options?.progress ?? (() => {});
     this.logging.event({
-      type: this.isReconnect ? "Reconnect" : "Connect",
+      type: "Connect",
       message: "Bluetooth connect start",
     });
-    if (this.isReconnect) {
-      this.callbacks.onReconnecting();
-    } else {
-      this.callbacks.onConnecting();
-    }
-
-    this.duringExplicitConnectDisconnect++;
+    this.callbacks.onConnecting();
 
     try {
       if (Capacitor.isNativePlatform()) {
@@ -174,17 +162,17 @@ export class BluetoothDeviceWrapper implements Logging {
       events.forEach((e) => this.startNotifications(e as TypedServiceEvent));
 
       this.logging.event({
-        type: this.isReconnect ? "Reconnect" : "Connect",
+        type: "Connect",
         message: "Bluetooth connect success",
       });
       this.callbacks.onSuccess();
     } catch (e) {
       this.logging.error("Bluetooth connect error", e);
       this.logging.event({
-        type: this.isReconnect ? "Reconnect" : "Connect",
+        type: "Connect",
         message: "Bluetooth connect failed",
       });
-      await this.disconnectInternal(false);
+      await this.disconnectInternal();
       this.callbacks.onFail();
 
       if (e instanceof DeviceError) {
@@ -210,10 +198,6 @@ export class BluetoothDeviceWrapper implements Logging {
         code: "bluetooth-connection-failed",
         message: e instanceof Error ? e.message : String(e),
       });
-    } finally {
-      this.duringExplicitConnectDisconnect--;
-      // Reset isReconnect for next time
-      this.isReconnect = false;
     }
   }
 
@@ -226,14 +210,11 @@ export class BluetoothDeviceWrapper implements Logging {
   }
 
   async disconnect(): Promise<void> {
-    return this.disconnectInternal(true);
+    return this.disconnectInternal();
   }
 
-  private async disconnectInternal(userTriggered: boolean): Promise<void> {
-    this.logging.log(
-      `Bluetooth disconnect ${userTriggered ? "(user triggered)" : "(programmatic)"}`,
-    );
-    this.duringExplicitConnectDisconnect++;
+  private async disconnectInternal(): Promise<void> {
+    this.logging.log("Bluetooth disconnect");
     try {
       if (this.connected) {
         await BleClient.disconnect(this.device.deviceId);
@@ -241,39 +222,16 @@ export class BluetoothDeviceWrapper implements Logging {
     } catch (e) {
       this.logging.error("Bluetooth GATT disconnect error (ignored)", e);
       // We might have already lost the connection.
-    } finally {
-      this.duringExplicitConnectDisconnect--;
     }
   }
 
-  async reconnect(): Promise<void> {
-    this.logging.log("Bluetooth reconnect");
-    this.isReconnect = true;
-    await this.connect();
-  }
-
-  handleDisconnectEvent = async (): Promise<void> => {
+  handleDisconnectEvent = (): void => {
     this.waitingForDisconnectEventCallbacks.forEach((cb) => cb());
     this.waitingForDisconnectEventCallbacks.length = 0;
 
     this.connected = false;
-    try {
-      if (!this.duringExplicitConnectDisconnect) {
-        this.logging.log(
-          "Bluetooth disconnected... automatically trying reconnect",
-        );
-        await this.reconnect();
-      } else {
-        this.logging.log(
-          "Bluetooth disconnect ignored during explicit disconnect",
-        );
-      }
-    } catch (e) {
-      this.logging.error(
-        "Bluetooth connect triggered by disconnect listener failed",
-        e,
-      );
-    }
+    this.logging.log("Bluetooth disconnect");
+    this.callbacks.onFail();
   };
 
   async getBoardVersion(): Promise<BoardVersion> {

--- a/lib/bluetooth-device-wrapper.ts
+++ b/lib/bluetooth-device-wrapper.ts
@@ -56,7 +56,7 @@ export interface Service {
 
 interface ConnectCallbacks {
   onConnecting: () => void;
-  onDisconnect: (clearConnection: boolean) => void;
+  onDisconnect: () => void;
   onSuccess: () => void;
 }
 
@@ -173,7 +173,7 @@ export class BluetoothDeviceWrapper implements Logging {
         message: "Bluetooth connect failed",
       });
       await this.disconnectInternal();
-      this.callbacks.onDisconnect(true);
+      this.callbacks.onDisconnect();
 
       if (e instanceof DeviceError) {
         throw e;
@@ -226,16 +226,12 @@ export class BluetoothDeviceWrapper implements Logging {
   }
 
   handleDisconnectEvent = (): void => {
-    const isExpectedDisconnect =
-      this.waitingForDisconnectEventCallbacks.length > 0;
     this.waitingForDisconnectEventCallbacks.forEach((cb) => cb());
     this.waitingForDisconnectEventCallbacks.length = 0;
 
     this.connected = false;
-    this.logging.log(
-      `Bluetooth ${isExpectedDisconnect ? "expected" : "unexpected"} disconnect`,
-    );
-    this.callbacks.onDisconnect(!isExpectedDisconnect);
+    this.logging.log("Bluetooth disconnect");
+    this.callbacks.onDisconnect();
   };
 
   async getBoardVersion(): Promise<BoardVersion> {

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -300,7 +300,7 @@ class MicrobitWebBluetoothConnectionImpl
     progress(ProgressStage.Initializing);
     throwIfUnavailable(await this.checkAvailability());
 
-    if (!this.connection) {
+    if (!this.device || !this.connection) {
       progress(ProgressStage.FindingDevice);
       const device = await this.requestDevice(options?.signal);
       this.connection = new BluetoothDeviceWrapper(
@@ -311,12 +311,7 @@ class MicrobitWebBluetoothConnectionImpl
         {
           onConnecting: () => this.setStatus(ConnectionStatus.CONNECTING),
           onSuccess: () => this.setStatus(ConnectionStatus.CONNECTED),
-          onDisconnect: (clearConnection: boolean) => {
-            this.setStatus(ConnectionStatus.DISCONNECTED);
-            if (clearConnection) {
-              this.connection = undefined;
-            }
-          },
+          onDisconnect: () => this.setStatus(ConnectionStatus.DISCONNECTED),
         },
       );
     }

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -311,9 +311,11 @@ class MicrobitWebBluetoothConnectionImpl
         {
           onConnecting: () => this.setStatus(ConnectionStatus.CONNECTING),
           onSuccess: () => this.setStatus(ConnectionStatus.CONNECTED),
-          onFail: () => {
+          onDisconnect: (clearConnection: boolean) => {
             this.setStatus(ConnectionStatus.DISCONNECTED);
-            this.connection = undefined;
+            if (clearConnection) {
+              this.connection = undefined;
+            }
           },
         },
       );
@@ -333,6 +335,7 @@ class MicrobitWebBluetoothConnectionImpl
         message: "error-disconnecting",
       });
     } finally {
+      console.trace("disconnected!");
       this.connection = undefined;
       this.setStatus(ConnectionStatus.DISCONNECTED);
       this.logging.event({
@@ -487,8 +490,10 @@ class MicrobitWebBluetoothConnectionImpl
       if (this.status !== ConnectionStatus.CONNECTED) {
         await this.connect({ progress, signal: options.signal });
       }
-
-      const connection = this.connection!;
+      if (!this.connection) {
+        throw new Error("Unexpected connection undefined!");
+      }
+      const connection = this.connection;
       try {
         const boardVersion = connection.boardVersion;
         if (!boardVersion) {
@@ -526,9 +531,11 @@ class MicrobitWebBluetoothConnectionImpl
           }
         }
       } catch (e) {
+        this.logging.log(`error! ${JSON.stringify(e)}`);
         this.error("Failed to flash", e);
         throw e;
       } finally {
+        this.logging.log("Disconnect finally!");
         await this.disconnect();
       }
     } finally {

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -330,7 +330,6 @@ class MicrobitWebBluetoothConnectionImpl
         message: "error-disconnecting",
       });
     } finally {
-      this.connection = undefined;
       this.setStatus(ConnectionStatus.DISCONNECTED);
       this.logging.event({
         type: "Bluetooth-info",

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -483,10 +483,8 @@ class MicrobitWebBluetoothConnectionImpl
       if (this.status !== ConnectionStatus.CONNECTED) {
         await this.connect({ progress, signal: options.signal });
       }
-      if (!this.connection) {
-        throw new Error("Unexpected connection undefined!");
-      }
-      const connection = this.connection;
+      
+      const connection = this.connection!;
       try {
         const boardVersion = connection.boardVersion;
         if (!boardVersion) {

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -310,7 +310,6 @@ class MicrobitWebBluetoothConnectionImpl
         () => this.getActiveEvents() as Array<keyof ServiceConnectionEventMap>,
         {
           onConnecting: () => this.setStatus(ConnectionStatus.CONNECTING),
-          onReconnecting: () => this.setStatus(ConnectionStatus.RECONNECTING),
           onSuccess: () => this.setStatus(ConnectionStatus.CONNECTED),
           onFail: () => {
             this.setStatus(ConnectionStatus.DISCONNECTED);

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -335,7 +335,6 @@ class MicrobitWebBluetoothConnectionImpl
         message: "error-disconnecting",
       });
     } finally {
-      console.trace("disconnected!");
       this.connection = undefined;
       this.setStatus(ConnectionStatus.DISCONNECTED);
       this.logging.event({
@@ -531,11 +530,9 @@ class MicrobitWebBluetoothConnectionImpl
           }
         }
       } catch (e) {
-        this.logging.log(`error! ${JSON.stringify(e)}`);
         this.error("Failed to flash", e);
         throw e;
       } finally {
-        this.logging.log("Disconnect finally!");
         await this.disconnect();
       }
     } finally {

--- a/lib/bluetooth.ts
+++ b/lib/bluetooth.ts
@@ -483,7 +483,7 @@ class MicrobitWebBluetoothConnectionImpl
       if (this.status !== ConnectionStatus.CONNECTED) {
         await this.connect({ progress, signal: options.signal });
       }
-      
+
       const connection = this.connection!;
       try {
         const boardVersion = connection.boardVersion;

--- a/lib/device.ts
+++ b/lib/device.ts
@@ -197,11 +197,6 @@ export enum ConnectionStatus {
    */
   CONNECTING = "CONNECTING",
   /**
-   * Reconnecting. When there is unexpected disruption in the connection,
-   * a reconnection is attempted.
-   */
-  RECONNECTING = "RECONNECTING",
-  /**
    * Paused due to tab visibility. The connection was temporarily suspended
    * because the browser tab became hidden. Reconnection will be attempted
    * automatically when the tab becomes visible again.

--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -100,7 +100,6 @@ class MicrobitRadioBridgeConnectionImpl
       // visibility, and now the tab is visible again so we should reconnect.
       const shouldReconnect = currentStatus === ConnectionStatus.PAUSED;
       if (shouldReconnect && this.serialSessionOpen) {
-        console.log("delegate listener serial session connect");
         this.serialSession?.connect();
       }
     }

--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -170,7 +170,10 @@ class MicrobitRadioBridgeConnectionImpl
         this.delegate,
         this.dispatchTypedEvent.bind(this),
         {
-          onConnecting: () => this.setStatus(ConnectionStatus.CONNECTING),
+          onConnecting: () => {
+            this.setStatus(ConnectionStatus.CONNECTING);
+            this.serialSessionOpen = true;
+          },
           onFailPreDispose: () => {
             this.ignoreDelegateStatus = false;
             this.serialSessionOpen = false;
@@ -373,7 +376,7 @@ class RadioBridgeSerialSession {
     } catch (e) {
       this.callbacks.onFailPreDispose();
       await this.dispose();
-      this.callbacks.onFailPostDispose()
+      this.callbacks.onFailPostDispose();
     }
   }
 

--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -74,12 +74,8 @@ class MicrobitRadioBridgeConnectionImpl
   private remoteDeviceId: number | undefined;
   private disconnectPromise: Promise<void> | undefined;
   private serialSessionOpen = false;
-  private ignoreDelegateStatus = false;
 
   private delegateStatusListener = (e: ConnectionStatusEvent) => {
-    if (this.ignoreDelegateStatus) {
-      return;
-    }
     const currentStatus = this.status;
     if (e.status !== ConnectionStatus.CONNECTED) {
       this.setStatus(e.status);
@@ -160,7 +156,6 @@ class MicrobitRadioBridgeConnectionImpl
       type: "Connect",
       message: "Serial connect start",
     });
-    this.ignoreDelegateStatus = false;
     await this.delegate.connect();
 
     try {
@@ -175,7 +170,6 @@ class MicrobitRadioBridgeConnectionImpl
             this.serialSessionOpen = true;
           },
           onFailPreDispose: () => {
-            this.ignoreDelegateStatus = false;
             this.serialSessionOpen = false;
           },
           onFailPostDispose: () => {
@@ -187,7 +181,6 @@ class MicrobitRadioBridgeConnectionImpl
             if (this.status !== ConnectionStatus.CONNECTED) {
               this.setStatus(ConnectionStatus.CONNECTED);
             }
-            this.ignoreDelegateStatus = false;
             this.serialSessionOpen = true;
           },
         },

--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -24,7 +24,7 @@ import {
 import * as protocol from "./usb-serial-protocol.js";
 import { MicrobitWebUSBConnection } from "./usb.js";
 
-const connectTimeoutDuration: number = 3_000;
+const connectTimeoutDuration: number = 10_000;
 
 class BridgeError extends Error {}
 class RemoteError extends Error {}
@@ -355,7 +355,7 @@ class RadioBridgeSerialSession {
         setTimeout(() => {
           this.onPeriodicMessageReceived = undefined;
           reject(new Error("Failed to receive data from remote micro:bit"));
-        }, 500);
+        }, connectTimeoutDuration);
       });
 
       const startCmdResponse = await this.sendCmdWaitResponse(startCmd);
@@ -426,16 +426,6 @@ class RadioBridgeSerialSession {
         if (
           this.lastReceivedMessageTimestamp &&
           Date.now() - this.lastReceivedMessageTimestamp > 1_000
-        ) {
-          this.logging.event({
-            type: "Serial",
-            message: "Serial connection lost...attempt to reconnect",
-          });
-        }
-        if (
-          this.lastReceivedMessageTimestamp &&
-          Date.now() - this.lastReceivedMessageTimestamp >
-            connectTimeoutDuration
         ) {
           this.logging.event({
             type: "Serial",

--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -24,7 +24,7 @@ import {
 import * as protocol from "./usb-serial-protocol.js";
 import { MicrobitWebUSBConnection } from "./usb.js";
 
-const connectTimeoutDuration: number = 10000;
+const connectTimeoutDuration: number = 3_000;
 
 class BridgeError extends Error {}
 class RemoteError extends Error {}
@@ -35,7 +35,7 @@ export interface MicrobitRadioBridgeConnectionOptions {
 
 interface ConnectCallbacks {
   onConnecting: () => void;
-  onRestartConnection: () => void;
+  onBeforeConnectionLostDispose: () => void;
   onFail: () => void;
   onSuccess: () => void;
 }
@@ -95,13 +95,12 @@ class MicrobitRadioBridgeConnectionImpl
       }
     } else {
       this.status = ConnectionStatus.DISCONNECTED;
-      // Reconnect the serial session if we were previously disconnected or paused.
+      // Reconnect the serial session if we were previously paused.
       // PAUSED means the USB connection was temporarily suspended due to tab
       // visibility, and now the tab is visible again so we should reconnect.
-      const shouldReconnect =
-        currentStatus === ConnectionStatus.DISCONNECTED ||
-        currentStatus === ConnectionStatus.PAUSED;
+      const shouldReconnect = currentStatus === ConnectionStatus.PAUSED;
       if (shouldReconnect && this.serialSessionOpen) {
+        console.log("delegate listener serial session connect");
         this.serialSession?.connect();
       }
     }
@@ -173,17 +172,14 @@ class MicrobitRadioBridgeConnectionImpl
         this.dispatchTypedEvent.bind(this),
         {
           onConnecting: () => this.setStatus(ConnectionStatus.CONNECTING),
-          onRestartConnection: () => {
-            // So that serial session does not get repetitively disposed in
-            // delegate status listener when delegate is disconnected for restarting connection
-            this.ignoreDelegateStatus = true;
+          onBeforeConnectionLostDispose: () => {
+            this.ignoreDelegateStatus = false;
+            this.serialSessionOpen = false;
           },
           onFail: () => {
             if (this.status !== ConnectionStatus.DISCONNECTED) {
               this.setStatus(ConnectionStatus.DISCONNECTED);
             }
-            this.ignoreDelegateStatus = false;
-            this.serialSessionOpen = false;
           },
           onSuccess: () => {
             if (this.status !== ConnectionStatus.CONNECTED) {
@@ -442,21 +438,16 @@ class RadioBridgeSerialSession {
           Date.now() - this.lastReceivedMessageTimestamp >
             connectTimeoutDuration
         ) {
-          await this.restartConnection();
+          this.logging.event({
+            type: "Serial",
+            message: "Serial connection lost",
+          });
+          this.callbacks.onBeforeConnectionLostDispose();
+          await this.dispose(true);
+          this.callbacks.onFail();
         }
       }, 1000);
     }
-  }
-
-  private async restartConnection() {
-    this.logging.event({
-      type: "Serial",
-      message: "Serial connection lost...restart connection",
-    });
-    this.callbacks.onRestartConnection();
-    await this.dispose(true);
-    await this.delegate.connect();
-    await this.connect();
   }
 
   private stopConnectionCheck() {

--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -35,7 +35,6 @@ export interface MicrobitRadioBridgeConnectionOptions {
 
 interface ConnectCallbacks {
   onConnecting: () => void;
-  onReconnecting: () => void;
   onRestartConnection: () => void;
   onFail: () => void;
   onSuccess: () => void;
@@ -174,12 +173,6 @@ class MicrobitRadioBridgeConnectionImpl
         this.dispatchTypedEvent.bind(this),
         {
           onConnecting: () => this.setStatus(ConnectionStatus.CONNECTING),
-          onReconnecting: () => {
-            // Leave serial connection running in case the remote device comes back.
-            if (this.status !== ConnectionStatus.RECONNECTING) {
-              this.setStatus(ConnectionStatus.RECONNECTING);
-            }
-          },
           onRestartConnection: () => {
             // So that serial session does not get repetitively disposed in
             // delegate status listener when delegate is disconnected for restarting connection
@@ -260,7 +253,6 @@ class RadioBridgeSerialSession {
   private onPeriodicMessageReceived: (() => void) | undefined;
   private lastReceivedMessageTimestamp: number | undefined;
   private connectionCheckIntervalId: ReturnType<typeof setInterval> | undefined;
-  private isRestartingConnection: boolean = false;
 
   private serialErrorListener = (event: SerialErrorEvent) => {
     this.logging.error("Serial error", event.error);
@@ -340,11 +332,7 @@ class RadioBridgeSerialSession {
     this.delegate.addEventListener("serialdata", this.serialDataListener);
     this.delegate.addEventListener("serialerror", this.serialErrorListener);
     try {
-      if (this.isRestartingConnection) {
-        this.callbacks.onReconnecting();
-      } else {
-        this.callbacks.onConnecting();
-      }
+      this.callbacks.onConnecting();
       await this.handshake();
 
       this.logging.log(`Serial: using remote device id ${this.remoteDeviceId}`);
@@ -385,7 +373,6 @@ class RadioBridgeSerialSession {
       // TODO: in the first-time connection case we used to move the error/disconnect to the background here, why? timing?
       await periodicMessagePromise;
 
-      this.isRestartingConnection = false;
       await this.startConnectionCheck();
       this.callbacks.onSuccess();
     } catch (e) {
@@ -449,7 +436,6 @@ class RadioBridgeSerialSession {
             type: "Serial",
             message: "Serial connection lost...attempt to reconnect",
           });
-          this.callbacks.onReconnecting();
         }
         if (
           this.lastReceivedMessageTimestamp &&
@@ -463,7 +449,6 @@ class RadioBridgeSerialSession {
   }
 
   private async restartConnection() {
-    this.isRestartingConnection = true;
     this.logging.event({
       type: "Serial",
       message: "Serial connection lost...restart connection",

--- a/lib/usb-radio-bridge.ts
+++ b/lib/usb-radio-bridge.ts
@@ -35,8 +35,8 @@ export interface MicrobitRadioBridgeConnectionOptions {
 
 interface ConnectCallbacks {
   onConnecting: () => void;
-  onBeforeConnectionLostDispose: () => void;
-  onFail: () => void;
+  onFailPreDispose: () => void;
+  onFailPostDispose: () => void;
   onSuccess: () => void;
 }
 
@@ -171,11 +171,11 @@ class MicrobitRadioBridgeConnectionImpl
         this.dispatchTypedEvent.bind(this),
         {
           onConnecting: () => this.setStatus(ConnectionStatus.CONNECTING),
-          onBeforeConnectionLostDispose: () => {
+          onFailPreDispose: () => {
             this.ignoreDelegateStatus = false;
             this.serialSessionOpen = false;
           },
-          onFail: () => {
+          onFailPostDispose: () => {
             if (this.status !== ConnectionStatus.DISCONNECTED) {
               this.setStatus(ConnectionStatus.DISCONNECTED);
             }
@@ -371,8 +371,9 @@ class RadioBridgeSerialSession {
       await this.startConnectionCheck();
       this.callbacks.onSuccess();
     } catch (e) {
-      this.callbacks.onFail();
+      this.callbacks.onFailPreDispose();
       await this.dispose();
+      this.callbacks.onFailPostDispose()
     }
   }
 
@@ -431,9 +432,9 @@ class RadioBridgeSerialSession {
             type: "Serial",
             message: "Serial connection lost",
           });
-          this.callbacks.onBeforeConnectionLostDispose();
+          this.callbacks.onFailPreDispose();
           await this.dispose(true);
-          this.callbacks.onFail();
+          this.callbacks.onFailPostDispose();
         }
       }, 1000);
     }


### PR DESCRIPTION
- Remove auto reconnect logic and `ConnectionStatus.Reconnecting` status in favour of the consuming app handling reconnections where necessary.
- Remove discarding of connection/device on disconnect in favour of the consuming app calling `clearDevice`. So unless the app calls `clearDevice`, we assume the same device is used for the connection.
- Extend radio bridge connection timeout to 10_000ms to match Bluetooth.
- Remove no longer needed `ignoreDelegateStatus`
- Keep serial session open when connecting to allow for reconnection after switch tabs