### PR TITLE
Skip partial flash when application hash already matches device

### DIFF
--- a/packages/microbit-connection/src/bluetooth.ts
+++ b/packages/microbit-connection/src/bluetooth.ts
@@ -534,7 +534,10 @@ class MicrobitWebBluetoothConnectionImpl
 
         if (partialFlashResult === PartialFlashResult.AttemptFullFlash) {
           await fullFlash(connection, boardVersion, memoryMap, progress);
-        } else if (partialFlashResult === PartialFlashResult.Success) {
+        } else if (
+          partialFlashResult === PartialFlashResult.AlreadyUpToDate ||
+          partialFlashResult === PartialFlashResult.Success
+        ) {
           this.waitForPostFlashDisconnectPromise = (async () => {
             try {
               if (connection.connected) {

--- a/packages/microbit-connection/src/flashing/flashing-makecode.test.ts
+++ b/packages/microbit-connection/src/flashing/flashing-makecode.test.ts
@@ -48,7 +48,13 @@ const hexFiles = [
     label: "MakeCode v0",
     universal: false,
     regions: [
-      { boardId: 0, start: 0x30c00, end: 0x3fc40, hash: "AB433FFB2EC06262" },
+      {
+        boardId: 0,
+        start: 0x30c00,
+        end: 0x3fc40,
+        hash: "AB433FFB2EC06262",
+        appHash: "653E46119D3A701B",
+      },
     ],
   },
   {
@@ -56,7 +62,13 @@ const hexFiles = [
     label: "MakeCode v1",
     universal: false,
     regions: [
-      { boardId: 0, start: 0x32c00, end: 0x3fc40, hash: "13FC432659DAE036" },
+      {
+        boardId: 0,
+        start: 0x32c00,
+        end: 0x3fc40,
+        hash: "13FC432659DAE036",
+        appHash: "579ACD9774545DAA",
+      },
     ],
   },
   {
@@ -64,7 +76,13 @@ const hexFiles = [
     label: "MakeCode v2",
     universal: false,
     regions: [
-      { boardId: 0, start: 0x34800, end: 0x3fc40, hash: "02F597B8CE253C03" },
+      {
+        boardId: 0,
+        start: 0x34800,
+        end: 0x3fc40,
+        hash: "02F597B8CE253C03",
+        appHash: "AF81BA51A0E7E921",
+      },
     ],
   },
   {
@@ -77,12 +95,14 @@ const hexFiles = [
         start: 0x35000,
         end: 0x3fc40,
         hash: "4F4FD28A88324C7E",
+        appHash: "C1008100AB00DD00",
       },
       {
         boardId: 0x9903,
         start: 0x45000,
         end: 0x7f340,
         hash: "FFC95E6502F1C747",
+        appHash: "DB0013005900BE00",
       },
     ],
   },
@@ -96,12 +116,14 @@ const hexFiles = [
         start: 0x35000,
         end: 0x3fc40,
         hash: "02E34856C566087A",
+        appHash: "54005A00F1008000",
       },
       {
         boardId: 0x9903,
         start: 0x47000,
         end: 0x7f340,
         hash: "8E4D117FB81B2B19",
+        appHash: "39006F00D900A600",
       },
     ],
   },
@@ -115,12 +137,14 @@ const hexFiles = [
         start: 0x36800,
         end: 0x3fc40,
         hash: "FFDA7A967870CC1B",
+        appHash: "E4006A0031002200",
       },
       {
         boardId: 0x9903,
         start: 0x47000,
         end: 0x7f340,
         hash: "3BD7683DA9B220E8",
+        appHash: "3E003800AF001600",
       },
     ],
   },
@@ -134,12 +158,14 @@ const hexFiles = [
         start: 0x35400,
         end: 0x3fc40,
         hash: "F4B5733CAAC69708",
+        appHash: "78005900AB000900",
       },
       {
         boardId: 0x9903,
         start: 0x47000,
         end: 0x7f340,
         hash: "890F5019E604A158",
+        appHash: "E300B400A6003100",
       },
     ],
   },
@@ -153,12 +179,14 @@ const hexFiles = [
         start: 0x35400,
         end: 0x3fc40,
         hash: "F87DD6F924D49825",
+        appHash: "2B00EF0092003900",
       },
       {
         boardId: 0x9903,
         start: 0x47000,
         end: 0x7f340,
         hash: "42B6FF95F591DA1F",
+        appHash: "9100F3005800E800",
       },
     ],
   },
@@ -172,12 +200,14 @@ const hexFiles = [
         start: 0x35400,
         end: 0x3fc40,
         hash: "8E76592A9CB06B29",
+        appHash: "8300A70050005500",
       },
       {
         boardId: 0x9903,
         start: 0x47000,
         end: 0x7f340,
         hash: "22204AC874977E7F",
+        appHash: "900022002E00BE00",
       },
     ],
   },
@@ -214,6 +244,7 @@ describe("findMakeCodeRegionInMemoryMap", () => {
             start: expected.start,
             end: expected.end,
             hash: expected.hash,
+            appHash: expected.appHash,
           });
         });
       }

--- a/packages/microbit-connection/src/flashing/flashing-makecode.ts
+++ b/packages/microbit-connection/src/flashing/flashing-makecode.ts
@@ -2,6 +2,12 @@ import MemoryMap from "nrf-intel-hex";
 import { RegionInfo } from "../partial-flashing-service.js";
 
 const PXT_MAGIC_HEX = "708E3B92C615A841C49866C975EE5197";
+const PXT_MAGIC_BYTES = PXT_MAGIC_HEX.length / 2; // 16
+
+export interface MakeCodeRegionInfo extends RegionInfo {
+  /** SHA-256 (truncated to 8 bytes) of the compiled program binary. */
+  appHash: string;
+}
 
 /**
  * Find the MakeCode code region in a MemoryMap (typically from a hex file).
@@ -9,14 +15,16 @@ const PXT_MAGIC_HEX = "708E3B92C615A841C49866C975EE5197";
 export const findMakeCodeRegionInMemoryMap = (
   memoryMap: MemoryMap,
   deviceCodeRegion: RegionInfo,
-): RegionInfo | null => {
+): MakeCodeRegionInfo | null => {
   for (const [blockAddr, block] of memoryMap) {
     const offset = findByteSequence(block, PXT_MAGIC_HEX);
     if (offset >= 0) {
       const start = blockAddr + offset;
-      const hashOffset = start + PXT_MAGIC_HEX.length / 2;
+      const hashOffset = start + PXT_MAGIC_BYTES;
       const hashBytes = memoryMap.slicePad(hashOffset, 8);
       const hash = bytesToHex(hashBytes);
+      const appHashBytes = memoryMap.slicePad(hashOffset + 8, 8);
+      const appHash = bytesToHex(appHashBytes);
 
       // Find the highest address with data in the memory map within the code region
       let end = start;
@@ -30,7 +38,7 @@ export const findMakeCodeRegionInMemoryMap = (
       // Round up to next 64-byte boundary
       end = Math.ceil(end / 64) * 64;
 
-      return { start, end, hash };
+      return { start, end, hash, appHash };
     }
   }
   return null;

--- a/packages/microbit-connection/src/flashing/flashing-partial.ts
+++ b/packages/microbit-connection/src/flashing/flashing-partial.ts
@@ -1,6 +1,7 @@
 import MemoryMap from "nrf-intel-hex";
 import { BluetoothDeviceWrapper } from "../bluetooth-device-wrapper.js";
 import {
+  MicroBitMode,
   PacketState,
   PartialFlashingService,
   RegionId,
@@ -21,6 +22,7 @@ const FLASH_PAGE_SIZE: Record<BoardVersion, number> = {
 
 export enum PartialFlashResult {
   Success = "Success",
+  AlreadyUpToDate = "AlreadyUpToDate",
   AttemptFullFlash = "AttemptFullFlash",
 }
 
@@ -114,6 +116,12 @@ const partialFlashInternal = async (
   if (deviceCodeRegion.start !== fileCodeRegion.start) {
     connection.log("Code start address doesn't match");
     return PartialFlashResult.AttemptFullFlash;
+  }
+
+  if (fileCodeRegion.appHash === deviceCodeRegion.hash) {
+    connection.log("Application hash matches, already up to date");
+    await pf.resetToMode(MicroBitMode.Application);
+    return PartialFlashResult.AlreadyUpToDate;
   }
 
   // The device-side partial flash service erases each flash page when it


### PR DESCRIPTION
Compare the MakeCode application hash from the hex file (SHA-256 truncated to 8 bytes, at magic+24) against the device's MakeCode region hash. When they match the program is already on the device, so we reset to application mode and return AlreadyUpToDate instead of reflashing identical data. This mirrors the optimisation in PXT's own Web BLE partial flashing code.

Fixes https://github.com/microbit-foundation/ml-trainer/issues/651