### PR TITLE
Reinstate "uBit" BLE name prefix support

### DIFF
--- a/packages/microbit-connection/src/bluetooth.ts
+++ b/packages/microbit-connection/src/bluetooth.ts
@@ -385,23 +385,21 @@ class MicrobitWebBluetoothConnectionImpl
   }
 
   private async requestDevice(signal?: AbortSignal): Promise<BleDevice> {
-    // TODO: is this possible to reinstate?
+    // Support both the default "BBC micro:bit" name and the shorter "uBit"
+    // name used by some MakeCode extensions (e.g. bsiever/microbit-pxt-blehid).
     // See https://github.com/bsiever/microbit-pxt-blehid/issues/31
-    // namePrefix: this.nameFilter
-    //   ? `uBit [${this.nameFilter}]`
-    //   : "uBit",
-    const namePrefix = this.nameFilter
-      ? `BBC micro:bit [${this.nameFilter}]`
-      : "BBC micro:bit";
+    const namePrefixes = this.nameFilter
+      ? [`BBC micro:bit [${this.nameFilter}]`, `uBit [${this.nameFilter}]`]
+      : ["BBC micro:bit", "uBit"];
 
     // If we have a cached device, check if it still matches the current filter.
     // If not, clear it so we find a new device.
     if (this.device) {
-      if (this.device.name?.startsWith(namePrefix)) {
+      if (namePrefixes.some((p) => this.device!.name?.startsWith(p))) {
         return this.device;
       }
       this.log(
-        `Cached device "${this.device.name}" doesn't match filter "${namePrefix}", clearing`,
+        `Cached device "${this.device.name}" doesn't match filters "${namePrefixes.join(", ")}", clearing`,
       );
       await this.clearDevice();
     }
@@ -409,8 +407,8 @@ class MicrobitWebBluetoothConnectionImpl
     this.dispatchTypedEvent("beforerequestdevice", new BeforeRequestDevice());
     try {
       this.device = Capacitor.isNativePlatform()
-        ? await this.requestDeviceNative(namePrefix, signal)
-        : await this.requestDeviceWeb(namePrefix);
+        ? await this.requestDeviceNative(namePrefixes, signal)
+        : await this.requestDeviceWeb(namePrefixes);
       if (!this.device) {
         this.setStatus(ConnectionStatus.NO_AUTHORIZED_DEVICE);
         throw new DeviceError({
@@ -586,29 +584,43 @@ class MicrobitWebBluetoothConnectionImpl
    * @returns device or undefined if user cancels.
    */
   private async requestDeviceWeb(
-    namePrefix: string,
+    namePrefixes: string[],
   ): Promise<BleDevice | undefined> {
+    const optionalServices = [
+      profile.accelerometer.id,
+      profile.button.id,
+      profile.deviceInformation.id,
+      profile.dfuControl.id,
+      profile.event.id,
+      profile.ioPin.id,
+      profile.led.id,
+      profile.magnetometer.id,
+      profile.temperature.id,
+      profile.uart.id,
+    ];
+    // Temporarily patch navigator.bluetooth.requestDevice to support multiple
+    // name prefix filters. The capacitor-ble plugin only supports a single
+    // namePrefix, but the Web Bluetooth API supports a filters array.
+    // By patching at this level the plugin's internal deviceMap is populated
+    // naturally when its own requestDevice completes.
+    const orig = navigator.bluetooth.requestDevice.bind(navigator.bluetooth);
     try {
+      navigator.bluetooth.requestDevice = (options?: RequestDeviceOptions) =>
+        orig({
+          ...options,
+          filters: namePrefixes.map((namePrefix) => ({ namePrefix })),
+        });
       return await BleClient.requestDevice({
-        namePrefix,
-        optionalServices: [
-          profile.accelerometer.id,
-          profile.button.id,
-          profile.deviceInformation.id,
-          profile.dfuControl.id,
-          profile.event.id,
-          profile.ioPin.id,
-          profile.led.id,
-          profile.magnetometer.id,
-          profile.temperature.id,
-          profile.uart.id,
-        ],
+        namePrefix: namePrefixes[0],
+        optionalServices,
       });
     } catch (e) {
       if (e instanceof DOMException && e.name === "NotFoundError") {
         return undefined;
       }
       throw e;
+    } finally {
+      navigator.bluetooth.requestDevice = orig;
     }
   }
 
@@ -619,22 +631,24 @@ class MicrobitWebBluetoothConnectionImpl
    * @throws DeviceError with code "aborted" if signal is aborted.
    */
   private async requestDeviceNative(
-    namePrefix: string,
+    namePrefixes: string[],
     signal?: AbortSignal,
   ): Promise<BleDevice | undefined> {
     if (signal?.aborted) {
       throw new DeviceError({ code: "aborted", message: "Connection aborted" });
     }
 
+    const matchesAnyPrefix = (name: string | undefined) =>
+      !!name && namePrefixes.some((p) => name.startsWith(p));
+
     // Check for existing bonded devices.
-    const bonded = await this.checkBondedDevices((device: BleDevice) => {
-      const name = device.name;
-      return !!name && name.startsWith(namePrefix);
-    });
+    const bonded = await this.checkBondedDevices((device: BleDevice) =>
+      matchesAnyPrefix(device.name),
+    );
     if (bonded) {
       return bonded;
     }
-    this.log(`Scanning for device - ${namePrefix}`);
+    this.log(`Scanning for device - ${namePrefixes.join(", ")}`);
     let found = false;
     let aborted = false;
     const scanPromise: Promise<BleDevice> = new Promise(
@@ -646,8 +660,8 @@ class MicrobitWebBluetoothConnectionImpl
           // localName on the device. So we filter here instead.  This happens on
           // iOS if DFU fails / is interrupted.
           if (
-            result.device.name?.startsWith(namePrefix) ||
-            result.localName?.startsWith(namePrefix)
+            matchesAnyPrefix(result.device.name) ||
+            matchesAnyPrefix(result.localName)
           ) {
             found = true;
             await BleClient.stopLEScan();


### PR DESCRIPTION
This was supported before the switch to the capacitor-ble plugin but dropped because RequestBleDeviceOptions only accepts a single namePrefix. On native, the scan and bonded device filters now match against either prefix. On web, we resort to a monkey patch. I'll raise an upstream issue.