### PR TITLE
Breaking: reorganize for better tree shaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,62 @@
 
 <a href="https://microbit-foundation.github.io/microbit-connection/" class="typedoc-ignore">This documentation is best viewed on the documentation site rather than GitHub or NPM package site.</a>
 
-This is a JavaScript library for micro:bit connections in browsers via USB and Bluetooth.
+A TypeScript library for connecting to micro:bit devices via USB and Bluetooth. Works in browsers (via WebUSB and Web Bluetooth) and in native iOS/Android apps (Bluetooth only, via [Capacitor](https://capacitorjs.com/)).
 
-This project is a work in progress. We are extracting WebUSB and Web Bluetooth code from the [micro:bit Python Editor](https://github.com/microbit-foundation/python-editor-v3/) and other projects. The API is not stable and it's not yet recommended that third parties use this project unless they are happy to update usage as the API evolves.
+[Available on NPM](https://www.npmjs.com/package/@microbit/microbit-connection).
 
-[Demo page](https://microbit-connection.pages.dev/) for this library.
+### Demo apps
 
-[Alpha releases are now on NPM](https://www.npmjs.com/package/@microbit/microbit-connection).
+- [Web demo](https://microbit-connection.pages.dev/) ([source](apps/demo/)) — WebUSB and Web Bluetooth in the browser
+- [Capacitor demo](apps/capacitor/) — Bluetooth on iOS and Android via Capacitor
 
-[micro:bit CreateAI](https://github.com/microbit-foundation/ml-trainer/) is already using this library for WebUSB and Web Bluetooth.
+### Projects using this library
 
-[This Python Editor PR](https://github.com/microbit-foundation/python-editor-v3/pull/1190) tracks updating the micro:bit Python Editor to use this library.
+- [micro:bit CreateAI](https://github.com/microbit-foundation/ml-trainer/) — uses USB and Bluetooth connections
+- [micro:bit Python Editor](https://github.com/microbit-foundation/python-editor-v3/) — [migration in progress](https://github.com/microbit-foundation/python-editor-v3/pull/1190)
+
+### Platform support
+
+| Feature              | Web (browser) | Native (Capacitor) |
+| -------------------- | ------------- | ------------------ |
+| USB connection       | WebUSB        | Not supported      |
+| Bluetooth connection | Web Bluetooth | iOS and Android    |
+| Flash via USB        | Yes           | Not supported      |
+| Flash via Bluetooth  | Not supported | iOS and Android    |
+
+## Entrypoints
+
+The library is split into separate entrypoints for tree-shaking. Import shared types from the root and connection-specific code from subpaths:
+
+| Import path                                   | Contents                                                                               |
+| --------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `@microbit/microbit-connection`               | Shared types and events (`ConnectionStatus`, `DeviceConnection`, `FlashOptions`, etc.) |
+| `@microbit/microbit-connection/bluetooth`     | `createBluetoothConnection` and Bluetooth connection types                             |
+| `@microbit/microbit-connection/usb`           | `createUSBConnection` and USB connection types                                         |
+| `@microbit/microbit-connection/universal-hex` | `createUniversalHexFlashDataSource` (depends on `@microbit/microbit-universal-hex`)    |
+| `@microbit/microbit-connection/radio-bridge`  | `createRadioBridgeConnection` for micro:bit radio bridge connections                   |
 
 ## Usage
 
 ### Flash a micro:bit
 
-Instantiate a WebUSB connection using {@link createWebUSBConnection} class and use it to connect to a micro:bit.
+Instantiate a WebUSB connection using {@link @microbit/microbit-connection/usb!createUSBConnection | createUSBConnection} and use it to connect to a micro:bit.
 
 ```ts
-import { createWebUSBConnection } from "@microbit/microbit-connection";
+import { createUSBConnection } from "@microbit/microbit-connection/usb";
 
-const usb = createWebUSBConnection();
+const usb = createUSBConnection();
 const connectionStatus = await usb.connect();
 
 console.log("Connection status: ", connectionStatus);
 ```
 
-{@link ConnectionStatus | Connection status} is `"CONNECTED"` if connection succeeds.
+{@link @microbit/microbit-connection!ConnectionStatus | Connection status} is `"CONNECTED"` if connection succeeds.
 
 Flash a universal hex that supports both V1 and V2:
 
 ```ts
-import { createUniversalHexFlashDataSource } from "@microbit/microbit-connection";
+import { createUniversalHexFlashDataSource } from "@microbit/microbit-connection/universal-hex";
 
 await usb.flash(createUniversalHexFlashDataSource(universalHexString), {
   partial: true,
@@ -46,7 +69,7 @@ await usb.flash(createUniversalHexFlashDataSource(universalHexString), {
 
 This code will also work for non-universal hex files so is a good default for unknown hex files.
 
-Alternatively, you can create and flash a hex for a specific micro:bit version by providing a function that takes a {@link BoardVersion} and returns a hex.
+Alternatively, you can create and flash a hex for a specific micro:bit version by providing a function that takes a {@link @microbit/microbit-connection!BoardVersion} and returns a hex.
 This can reduce download size or help integrate with APIs that produce a hex for a particular device version.
 This example uses the [@microbit/microbit-fs library](https://microbit-foundation.github.io/microbit-fs/) which can return a hex based on board id.
 
@@ -74,26 +97,26 @@ await usb.flash(
 );
 ```
 
-For more examples of using other methods in the {@link MicrobitWebUSBConnection} class, see our [demo code](https://github.com/microbit-foundation/microbit-connection/blob/main/src/demo.ts) for our [demo site](https://microbit-connection.pages.dev/).
+For more examples see the [web demo source](apps/demo/src/demo.ts) and the [Capacitor demo source](apps/capacitor/src/).
 
 ### Connect via Bluetooth
 
 By default, the micro:bit's Bluetooth service is not enabled. Visit our [Bluetooth tech site page](https://tech.microbit.org/bluetooth/) to download a hex file that would enable the bluetooth service.
 
-Instantiate a Bluetooth connection using {@link createWebBluetoothConnection} class and use it to connect to a micro:bit.
+Instantiate a Bluetooth connection using {@link @microbit/microbit-connection/bluetooth!createBluetoothConnection | createBluetoothConnection} class and use it to connect to a micro:bit.
 
 ```ts
-import { createWebBluetoothConnection } from "@microbit/microbit-connection";
+import { createBluetoothConnection } from "@microbit/microbit-connection/bluetooth";
 
-const bluetooth = createWebBluetoothConnection();
+const bluetooth = createBluetoothConnection();
 const connectionStatus = await bluetooth.connect();
 
 console.log("Connection status: ", connectionStatus);
 ```
 
-{@link ConnectionStatus | Connection status} is `"CONNECTED"` if connection succeeds.
+{@link @microbit/microbit-connection!ConnectionStatus | Connection status} is `"CONNECTED"` if connection succeeds.
 
-For more examples of using other methods in the {@link createWebBluetoothConnection} class, see our [demo code](https://github.com/microbit-foundation/microbit-connection/blob/main/src/demo.ts) for our [demo site](https://microbit-connection.pages.dev/).
+For more examples see the [web demo source](apps/demo/src/demo.ts) and the [Capacitor demo source](apps/capacitor/src/).
 
 ## Known limitations
 

--- a/apps/capacitor/src/App.tsx
+++ b/apps/capacitor/src/App.tsx
@@ -3,9 +3,9 @@ import HomeScreen from "./components/HomeScreen";
 import MakeCodeView from "./components/MakeCodeView";
 import "./App.css";
 import ConnectionProvider from "./components/ConnectionProvider";
-import { createWebBluetoothConnection } from "@microbit/microbit-connection";
+import { createBluetoothConnection } from "@microbit/microbit-connection/bluetooth";
 
-const connection = createWebBluetoothConnection();
+const connection = createBluetoothConnection();
 
 function App() {
   return (

--- a/apps/capacitor/src/components/ConnectionProvider.tsx
+++ b/apps/capacitor/src/components/ConnectionProvider.tsx
@@ -1,10 +1,10 @@
-import { MicrobitWebBluetoothConnection } from "@microbit/microbit-connection";
+import { type MicrobitBluetoothConnection } from "@microbit/microbit-connection/bluetooth";
 import { ReactNode, useEffect, useState } from "react";
 import { ConnectionContext } from "../hooks/use-connection";
 
 interface ConnectionProviderProps {
   children: ReactNode;
-  connection: MicrobitWebBluetoothConnection;
+  connection: MicrobitBluetoothConnection;
 }
 
 const ConnectionProvider = ({

--- a/apps/capacitor/src/flashing/index.ts
+++ b/apps/capacitor/src/flashing/index.ts
@@ -1,11 +1,9 @@
-import {
-  createUniversalHexFlashDataSource,
-  type ProgressCallback,
-  MicrobitWebBluetoothConnection,
-} from "@microbit/microbit-connection";
+import { type ProgressCallback } from "@microbit/microbit-connection";
+import { createUniversalHexFlashDataSource } from "@microbit/microbit-connection/universal-hex";
+import { type MicrobitBluetoothConnection } from "@microbit/microbit-connection/bluetooth";
 
 export async function flash(
-  connection: MicrobitWebBluetoothConnection,
+  connection: MicrobitBluetoothConnection,
   deviceName: string,
   hexStr: string,
   progress: ProgressCallback,

--- a/apps/capacitor/src/hooks/use-connection.ts
+++ b/apps/capacitor/src/hooks/use-connection.ts
@@ -3,12 +3,12 @@ import {
   AccelerometerDataEvent,
   ConnectionStatus,
   ConnectionStatusEvent,
-  MicrobitWebBluetoothConnection,
 } from "@microbit/microbit-connection";
+import { type MicrobitBluetoothConnection } from "@microbit/microbit-connection/bluetooth";
 import { createContext, useContext, useEffect, useState } from "react";
 
 export const ConnectionContext = createContext<
-  undefined | MicrobitWebBluetoothConnection
+  undefined | MicrobitBluetoothConnection
 >(undefined);
 
 export const useConnection = () => {

--- a/apps/capacitor/vite.config.ts
+++ b/apps/capacitor/vite.config.ts
@@ -7,6 +7,22 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
+      "@microbit/microbit-connection/bluetooth": resolve(
+        __dirname,
+        "../../packages/microbit-connection/src/bluetooth-entrypoint.ts",
+      ),
+      "@microbit/microbit-connection/usb": resolve(
+        __dirname,
+        "../../packages/microbit-connection/src/usb-entrypoint.ts",
+      ),
+      "@microbit/microbit-connection/radio-bridge": resolve(
+        __dirname,
+        "../../packages/microbit-connection/src/radio-bridge-entrypoint.ts",
+      ),
+      "@microbit/microbit-connection/universal-hex": resolve(
+        __dirname,
+        "../../packages/microbit-connection/src/universal-hex-entrypoint.ts",
+      ),
       "@microbit/microbit-connection": resolve(
         __dirname,
         "../../packages/microbit-connection/src/index.ts",

--- a/apps/demo/src/demo.ts
+++ b/apps/demo/src/demo.ts
@@ -10,37 +10,43 @@ import {
   ButtonEvent,
   ConnectionStatus,
   ConnectionStatusEvent,
-  createRadioBridgeConnection,
-  createUniversalHexFlashDataSource,
-  createWebBluetoothConnection,
-  createWebUSBConnection,
-  DeviceSelectionMode,
   MagnetometerDataEvent,
-  MicrobitRadioBridgeConnection,
-  MicrobitWebBluetoothConnection,
-  MicrobitWebUSBConnection,
   SerialDataEvent,
   UARTDataEvent,
 } from "@microbit/microbit-connection";
+import {
+  createBluetoothConnection,
+  type MicrobitBluetoothConnection,
+} from "@microbit/microbit-connection/bluetooth";
+import {
+  createUSBConnection,
+  DeviceSelectionMode,
+  type MicrobitUSBConnection,
+} from "@microbit/microbit-connection/usb";
+import {
+  createRadioBridgeConnection,
+  type MicrobitRadioBridgeConnection,
+} from "@microbit/microbit-connection/radio-bridge";
+import { createUniversalHexFlashDataSource } from "@microbit/microbit-connection/universal-hex";
 import "./demo.css";
 
 type ConnectionType = "usb" | "bluetooth" | "radio";
 
 type TypedConnection =
   | { type: "radio"; connection: MicrobitRadioBridgeConnection }
-  | { type: "bluetooth"; connection: MicrobitWebBluetoothConnection }
-  | { type: "usb"; connection: MicrobitWebUSBConnection };
+  | { type: "bluetooth"; connection: MicrobitBluetoothConnection }
+  | { type: "usb"; connection: MicrobitUSBConnection };
 
 const createConnections = (
   type: "usb" | "bluetooth" | "radio",
 ): TypedConnection => {
   switch (type) {
     case "bluetooth":
-      return { type, connection: createWebBluetoothConnection() };
+      return { type, connection: createBluetoothConnection() };
     case "usb":
       return {
         type,
-        connection: createWebUSBConnection({
+        connection: createUSBConnection({
           deviceSelectionMode: DeviceSelectionMode.UseAnyAllowed,
         }),
       };
@@ -48,7 +54,7 @@ const createConnections = (
       // This only works with the local-sensor hex.
       // To use with a remote micro:bit we need a UI flow that grabs and sets the remote id.
       const connection = createRadioBridgeConnection(
-        createWebUSBConnection({
+        createUSBConnection({
           deviceSelectionMode: DeviceSelectionMode.UseAnyAllowed,
         }),
       );

--- a/apps/demo/vite.config.mts
+++ b/apps/demo/vite.config.mts
@@ -4,6 +4,22 @@ import { defineConfig } from "vite";
 export default defineConfig({
   resolve: {
     alias: {
+      "@microbit/microbit-connection/bluetooth": resolve(
+        __dirname,
+        "../../packages/microbit-connection/src/bluetooth-entrypoint.ts",
+      ),
+      "@microbit/microbit-connection/usb": resolve(
+        __dirname,
+        "../../packages/microbit-connection/src/usb-entrypoint.ts",
+      ),
+      "@microbit/microbit-connection/radio-bridge": resolve(
+        __dirname,
+        "../../packages/microbit-connection/src/radio-bridge-entrypoint.ts",
+      ),
+      "@microbit/microbit-connection/universal-hex": resolve(
+        __dirname,
+        "../../packages/microbit-connection/src/universal-hex-entrypoint.ts",
+      ),
       "@microbit/microbit-connection": resolve(
         __dirname,
         "../../packages/microbit-connection/src/index.ts",

--- a/packages/microbit-connection/package.json
+++ b/packages/microbit-connection/package.json
@@ -7,6 +7,7 @@
   "files": [
     "build"
   ],
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": {
@@ -16,6 +17,46 @@
       "require": {
         "types": "./build/cjs/index.d.ts",
         "default": "./build/cjs/index.js"
+      }
+    },
+    "./bluetooth": {
+      "import": {
+        "types": "./build/esm/bluetooth-entrypoint.d.ts",
+        "default": "./build/esm/bluetooth-entrypoint.js"
+      },
+      "require": {
+        "types": "./build/cjs/bluetooth-entrypoint.d.ts",
+        "default": "./build/cjs/bluetooth-entrypoint.js"
+      }
+    },
+    "./usb": {
+      "import": {
+        "types": "./build/esm/usb-entrypoint.d.ts",
+        "default": "./build/esm/usb-entrypoint.js"
+      },
+      "require": {
+        "types": "./build/cjs/usb-entrypoint.d.ts",
+        "default": "./build/cjs/usb-entrypoint.js"
+      }
+    },
+    "./universal-hex": {
+      "import": {
+        "types": "./build/esm/universal-hex-entrypoint.d.ts",
+        "default": "./build/esm/universal-hex-entrypoint.js"
+      },
+      "require": {
+        "types": "./build/cjs/universal-hex-entrypoint.d.ts",
+        "default": "./build/cjs/universal-hex-entrypoint.js"
+      }
+    },
+    "./radio-bridge": {
+      "import": {
+        "types": "./build/esm/radio-bridge-entrypoint.d.ts",
+        "default": "./build/esm/radio-bridge-entrypoint.js"
+      },
+      "require": {
+        "types": "./build/cjs/radio-bridge-entrypoint.d.ts",
+        "default": "./build/cjs/radio-bridge-entrypoint.js"
       }
     }
   },

--- a/packages/microbit-connection/src/bluetooth-entrypoint.ts
+++ b/packages/microbit-connection/src/bluetooth-entrypoint.ts
@@ -1,0 +1,8 @@
+/**
+ * @module @microbit/microbit-connection/bluetooth
+ */
+export {
+  createBluetoothConnection,
+  type MicrobitBluetoothConnection,
+  type MicrobitBluetoothConnectionOptions,
+} from "./bluetooth.js";

--- a/packages/microbit-connection/src/bluetooth.test.ts
+++ b/packages/microbit-connection/src/bluetooth.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { ConnectionStatus, ConnectionStatusEvent } from "./device.js";
-import { createWebBluetoothConnection } from "./bluetooth.js";
+import { createBluetoothConnection } from "./bluetooth.js";
 import { expect, vi, describe, it } from "vitest";
 
 // Mock Capacitor
@@ -55,7 +55,7 @@ const setupNavigatorMock = () => {
 describe("Bluetooth connection status events", () => {
   it("emits status events with correct previousStatus", async () => {
     setupNavigatorMock();
-    const connection = createWebBluetoothConnection();
+    const connection = createBluetoothConnection();
     await connection.initialize();
 
     expect(connection.status).toBe(ConnectionStatus.NO_AUTHORIZED_DEVICE);
@@ -76,7 +76,7 @@ describe("Bluetooth connection status events", () => {
 
   it("defers status updates during flash, emitting single catch-up event", async () => {
     setupNavigatorMock();
-    const connection = createWebBluetoothConnection();
+    const connection = createBluetoothConnection();
     await connection.initialize();
 
     const statusBeforeFlash = connection.status;

--- a/packages/microbit-connection/src/bluetooth.ts
+++ b/packages/microbit-connection/src/bluetooth.ts
@@ -44,7 +44,7 @@ import {
 } from "./service-events.js";
 
 import { throwIfUnavailable } from "./availability.js";
-import { truncateHexAfterEof } from "./hex-flash-data-source.js";
+import { truncateHexAfterEof } from "./hex-util.js";
 import {
   DefaultDeviceBondState,
   DeviceBondState,
@@ -55,12 +55,12 @@ type BleClientError = { message: string; errorMessage: string };
 
 let bleClientInitialized = false;
 
-export interface MicrobitWebBluetoothConnectionOptions {
+export interface MicrobitBluetoothConnectionOptions {
   logging?: Logging;
   deviceBondState?: DeviceBondState;
 }
 
-export interface MicrobitWebBluetoothConnection
+export interface MicrobitBluetoothConnection
   extends DeviceConnection<ServiceConnectionEventMap> {
   /**
    * Sets micro:bit name filter for device requesting.
@@ -165,31 +165,22 @@ export interface MicrobitWebBluetoothConnection
    */
   uartWrite(data: Uint8Array): Promise<void>;
 
-  /**
-   * Flash the micro:bit.
-   *
-   * @param dataSource The data to use.
-   * @param options Flash options and progress callback.
-   * @throws {DeviceError} On flash failure. The error.code property indicates the failure type.
-   * @throws {FlashDataError} If data preparation fails.
-   */
   flash(dataSource: FlashDataSource, options: FlashOptions): Promise<void>;
 }
 
 /**
  * A Bluetooth connection factory.
  */
-export const createWebBluetoothConnection = (
-  options?: MicrobitWebBluetoothConnectionOptions,
-): MicrobitWebBluetoothConnection =>
-  new MicrobitWebBluetoothConnectionImpl(options);
+export const createBluetoothConnection = (
+  options?: MicrobitBluetoothConnectionOptions,
+): MicrobitBluetoothConnection => new MicrobitBluetoothConnectionImpl(options);
 
 /**
  * A Bluetooth connection to a micro:bit device.
  */
-class MicrobitWebBluetoothConnectionImpl
+class MicrobitBluetoothConnectionImpl
   extends TypedEventTarget<DeviceConnectionEventMap & ServiceConnectionEventMap>
-  implements MicrobitWebBluetoothConnection
+  implements MicrobitBluetoothConnection
 {
   status: ConnectionStatus = ConnectionStatus.NO_AUTHORIZED_DEVICE;
 
@@ -207,7 +198,7 @@ class MicrobitWebBluetoothConnectionImpl
   private deferredUpdatesPreviousStatus: ConnectionStatus | undefined;
   private waitForPostFlashDisconnectPromise: Promise<void> | undefined;
 
-  constructor(options: MicrobitWebBluetoothConnectionOptions = {}) {
+  constructor(options: MicrobitBluetoothConnectionOptions = {}) {
     super();
     this.logging = options.logging || new ConsoleLogging();
     this.deviceBondState =

--- a/packages/microbit-connection/src/device.ts
+++ b/packages/microbit-connection/src/device.ts
@@ -351,6 +351,20 @@ export interface DeviceConnection<M extends ValueIsEvent<M>>
   serialWrite(data: string): Promise<void>;
 
   /**
+   * Flash the micro:bit.
+   *
+   * Not all connection types support flashing. For example, radio bridge
+   * connections do not support flashing, and Bluetooth connections only
+   * support flashing on native platforms (not Web).
+   *
+   * @param dataSource The data to use.
+   * @param options Flash options and progress callback.
+   * @throws {DeviceError} On flash failure. The error.code property indicates the failure type.
+   * @throws {FlashDataError} If data preparation fails.
+   */
+  flash?(dataSource: FlashDataSource, options: FlashOptions): Promise<void>;
+
+  /**
    * Clear device to enable chooseDevice.
    */
   clearDevice(): Promise<void> | void;

--- a/packages/microbit-connection/src/flashing/flashing-makecode.test.ts
+++ b/packages/microbit-connection/src/flashing/flashing-makecode.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@microbit/microbit-universal-hex";
 import { findMakeCodeRegionInMemoryMap } from "./flashing-makecode.js";
 import { RegionInfo } from "../partial-flashing-service.js";
-import { truncateHexAfterEof } from "../hex-flash-data-source.js";
+import { truncateHexAfterEof } from "../hex-util.js";
 
 const hexDir = resolve(__dirname, "../../examples");
 

--- a/packages/microbit-connection/src/hex-flash-data-source.ts
+++ b/packages/microbit-connection/src/hex-flash-data-source.ts
@@ -1,3 +1,6 @@
+// This module is deliberately kept separate so that
+// @microbit/microbit-universal-hex can be tree-shaken by bundlers
+// when consumers don't use createUniversalHexFlashDataSource.
 import { BoardId } from "./board-id.js";
 import {
   FlashDataError as FlashDataError,
@@ -8,16 +11,6 @@ import {
   isUniversalHex,
   separateUniversalHex,
 } from "@microbit/microbit-universal-hex";
-
-// MakeCode hex files may contain embedded source in custom record types
-// (type 0x0E) after the EOF record, and older files may have trailing blank
-// lines. The nrf-intel-hex parser rejects any data after EOF, so we truncate.
-export const truncateHexAfterEof = (hex: string): string => {
-  // The EOF record is :00000001FF (case-insensitive per the Intel HEX spec).
-  const eofIdx = hex.search(/:00000001FF/i);
-  if (eofIdx < 0) return hex;
-  return hex.slice(0, eofIdx + ":00000001FF".length) + "\n";
-};
 
 /**
  * A flash data source that converts universal hex files as needed.

--- a/packages/microbit-connection/src/hex-util.ts
+++ b/packages/microbit-connection/src/hex-util.ts
@@ -1,0 +1,9 @@
+// MakeCode hex files may contain embedded source in custom record types
+// (type 0x0E) after the EOF record, and older files may have trailing blank
+// lines. The nrf-intel-hex parser rejects any data after EOF, so we truncate.
+export const truncateHexAfterEof = (hex: string): string => {
+  // The EOF record is :00000001FF (case-insensitive per the Intel HEX spec).
+  const eofIdx = hex.search(/:00000001FF/i);
+  if (eofIdx < 0) return hex;
+  return hex.slice(0, eofIdx + ":00000001FF".length) + "\n";
+};

--- a/packages/microbit-connection/src/index.ts
+++ b/packages/microbit-connection/src/index.ts
@@ -1,9 +1,7 @@
+/**
+ * @module @microbit/microbit-connection
+ */
 import { AccelerometerData, AccelerometerDataEvent } from "./accelerometer.js";
-import {
-  createWebBluetoothConnection,
-  MicrobitWebBluetoothConnection,
-  MicrobitWebBluetoothConnectionOptions,
-} from "./bluetooth.js";
 import { BoardId } from "./board-id.js";
 import { ButtonEvent, ButtonEventType, ButtonState } from "./buttons.js";
 import { DeviceBondState } from "./device-bond-state.js";
@@ -27,7 +25,6 @@ import {
   ProgressStage,
 } from "./device.js";
 import { TypedEventTarget } from "./events.js";
-import { createUniversalHexFlashDataSource } from "./hex-flash-data-source.js";
 import { LedMatrix } from "./led.js";
 import { Logging, LoggingEvent } from "./logging.js";
 import { MagnetometerData, MagnetometerDataEvent } from "./magnetometer.js";
@@ -40,17 +37,6 @@ import {
 } from "./serial-events.js";
 import { ServiceConnectionEventMap } from "./service-events.js";
 import { UARTDataEvent } from "./uart.js";
-import {
-  createRadioBridgeConnection,
-  MicrobitRadioBridgeConnection,
-  MicrobitRadioBridgeConnectionOptions,
-} from "./usb-radio-bridge.js";
-import {
-  createWebUSBConnection,
-  DeviceSelectionMode,
-  MicrobitWebUSBConnection,
-  MicrobitWebUSBConnectionOptions,
-} from "./usb.js";
 
 export {
   AfterRequestDevice,
@@ -59,12 +45,7 @@ export {
   BoardId,
   ConnectionStatus,
   ConnectionStatusEvent,
-  createRadioBridgeConnection,
-  createUniversalHexFlashDataSource,
-  createWebBluetoothConnection,
-  createWebUSBConnection,
   DeviceConnectionEventMap,
-  DeviceSelectionMode,
   DeviceError,
   FlashDataError,
   FlashEvent,
@@ -97,11 +78,5 @@ export type {
   LoggingEvent,
   MagnetometerData,
   MagnetometerDataEvent,
-  MicrobitRadioBridgeConnection,
-  MicrobitRadioBridgeConnectionOptions,
-  MicrobitWebBluetoothConnection,
-  MicrobitWebBluetoothConnectionOptions,
-  MicrobitWebUSBConnection,
-  MicrobitWebUSBConnectionOptions,
   ProgressCallback,
 };

--- a/packages/microbit-connection/src/radio-bridge-entrypoint.ts
+++ b/packages/microbit-connection/src/radio-bridge-entrypoint.ts
@@ -1,0 +1,8 @@
+/**
+ * @module @microbit/microbit-connection/radio-bridge
+ */
+export {
+  createRadioBridgeConnection,
+  type MicrobitRadioBridgeConnection,
+  type MicrobitRadioBridgeConnectionOptions,
+} from "./usb-radio-bridge.js";

--- a/packages/microbit-connection/src/universal-hex-entrypoint.ts
+++ b/packages/microbit-connection/src/universal-hex-entrypoint.ts
@@ -1,0 +1,4 @@
+/**
+ * @module @microbit/microbit-connection/universal-hex
+ */
+export { createUniversalHexFlashDataSource } from "./hex-flash-data-source.js";

--- a/packages/microbit-connection/src/usb-entrypoint.ts
+++ b/packages/microbit-connection/src/usb-entrypoint.ts
@@ -1,0 +1,9 @@
+/**
+ * @module @microbit/microbit-connection/usb
+ */
+export {
+  createUSBConnection,
+  DeviceSelectionMode,
+  type MicrobitUSBConnection,
+  type MicrobitUSBConnectionOptions,
+} from "./usb.js";

--- a/packages/microbit-connection/src/usb-partial-flashing.ts
+++ b/packages/microbit-connection/src/usb-partial-flashing.ts
@@ -59,7 +59,7 @@ import {
   read32FromUInt8Array,
 } from "./usb-partial-flashing-utils.js";
 import { BoardVersion, ProgressCallback, ProgressStage } from "./device.js";
-import { truncateHexAfterEof } from "./hex-flash-data-source.js";
+import { truncateHexAfterEof } from "./hex-util.js";
 import MemoryMap from "nrf-intel-hex";
 
 // Source code for binaries in can be found at https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/external/sha/source/main.c

--- a/packages/microbit-connection/src/usb-radio-bridge.ts
+++ b/packages/microbit-connection/src/usb-radio-bridge.ts
@@ -22,7 +22,7 @@ import {
   TypedServiceEventDispatcher,
 } from "./service-events.js";
 import * as protocol from "./usb-serial-protocol.js";
-import { MicrobitWebUSBConnection } from "./usb.js";
+import { MicrobitUSBConnection } from "./usb.js";
 
 const connectTimeoutDuration: number = 10_000;
 
@@ -54,7 +54,7 @@ export interface MicrobitRadioBridgeConnection
  * A radio bridge connection factory.
  */
 export const createRadioBridgeConnection = (
-  delegate: MicrobitWebUSBConnection,
+  delegate: MicrobitUSBConnection,
   options?: MicrobitRadioBridgeConnectionOptions,
 ): MicrobitRadioBridgeConnection =>
   new MicrobitRadioBridgeConnectionImpl(delegate, options);
@@ -102,7 +102,7 @@ class MicrobitRadioBridgeConnectionImpl
   };
 
   constructor(
-    private delegate: MicrobitWebUSBConnection,
+    private delegate: MicrobitUSBConnection,
     options?: MicrobitRadioBridgeConnectionOptions,
   ) {
     super();
@@ -314,7 +314,7 @@ class RadioBridgeSerialSession {
   constructor(
     private logging: Logging,
     private remoteDeviceId: number,
-    private delegate: MicrobitWebUSBConnection,
+    private delegate: MicrobitUSBConnection,
     private dispatchTypedEvent: TypedServiceEventDispatcher,
     private callbacks: ConnectCallbacks,
   ) {}

--- a/packages/microbit-connection/src/usb.test.ts
+++ b/packages/microbit-connection/src/usb.test.ts
@@ -10,7 +10,7 @@
  * with a tweak to Buffer.
  */
 import { ConnectionStatus, ConnectionStatusEvent } from "./device.js";
-import { applyDeviceFilters, createWebUSBConnection } from "./usb.js";
+import { applyDeviceFilters, createUSBConnection } from "./usb.js";
 import { beforeAll, beforeEach, expect, vi, describe, it } from "vitest";
 
 vi.mock("./usb-device-wrapper.js", () => ({
@@ -26,10 +26,10 @@ const describeDeviceOnly = process.env.TEST_MODE_DEVICE
   ? describe
   : describe.skip;
 
-describe("MicrobitWebUSBConnection (WebUSB unsupported)", () => {
+describe("MicrobitUSBConnection (WebUSB unsupported)", () => {
   it("checkAvailability returns unsupported when WebUSB isn't available", async () => {
     vi.stubGlobal("navigator", {});
-    const microbit = createWebUSBConnection();
+    const microbit = createUSBConnection();
     expect(await microbit.checkAvailability()).toBe("unsupported");
     vi.unstubAllGlobals();
   });
@@ -41,7 +41,7 @@ describe("MicrobitWebUSBConnection (WebUSB unsupported)", () => {
         },
       },
     });
-    const microbit = createWebUSBConnection();
+    const microbit = createUSBConnection();
     expect(microbit.status).toBe(ConnectionStatus.NO_AUTHORIZED_DEVICE);
     const afterRequestDevice = vi.fn();
     microbit.addEventListener("afterrequestdevice", afterRequestDevice);
@@ -53,7 +53,7 @@ describe("MicrobitWebUSBConnection (WebUSB unsupported)", () => {
   });
 });
 
-describeDeviceOnly("MicrobitWebUSBConnection (WebUSB supported)", () => {
+describeDeviceOnly("MicrobitUSBConnection (WebUSB supported)", () => {
   beforeAll(() => {
     const usb = {
       addEventListener: vi.fn(),
@@ -70,13 +70,13 @@ describeDeviceOnly("MicrobitWebUSBConnection (WebUSB supported)", () => {
   });
 
   it("shows no device as initial status", () => {
-    const microbit = createWebUSBConnection();
+    const microbit = createUSBConnection();
     expect(microbit.status).toBe(ConnectionStatus.NO_AUTHORIZED_DEVICE);
   });
 
   it("connects and disconnects updating status and events", async () => {
     const events: ConnectionStatus[] = [];
-    const connection = createWebUSBConnection();
+    const connection = createUSBConnection();
     connection.addEventListener("status", (event: ConnectionStatusEvent) => {
       events.push(event.status);
     });
@@ -183,7 +183,7 @@ describe("Tab visibility and PAUSED state", () => {
   });
 
   const waitForStatus = (
-    connection: ReturnType<typeof createWebUSBConnection>,
+    connection: ReturnType<typeof createUSBConnection>,
     status: ConnectionStatus,
   ) =>
     new Promise<void>((resolve) => {
@@ -201,7 +201,7 @@ describe("Tab visibility and PAUSED state", () => {
     });
 
   it("pauses when tab becomes hidden while connected", async () => {
-    const connection = createWebUSBConnection();
+    const connection = createUSBConnection();
     await connection.initialize();
     await connection.connect();
     expect(connection.status).toBe(ConnectionStatus.CONNECTED);
@@ -214,7 +214,7 @@ describe("Tab visibility and PAUSED state", () => {
   });
 
   it("reconnects when tab becomes visible while paused", async () => {
-    const connection = createWebUSBConnection();
+    const connection = createUSBConnection();
     await connection.initialize();
     await connection.connect();
 

--- a/packages/microbit-connection/src/usb.ts
+++ b/packages/microbit-connection/src/usb.ts
@@ -58,7 +58,7 @@ export enum DeviceSelectionMode {
   UseAnyAllowed = "UseAnyAllowed",
 }
 
-export interface MicrobitWebUSBConnectionOptions {
+export interface MicrobitUSBConnectionOptions {
   // We should copy this type when extracting a library, and make it optional.
   // Coupling for now to make it easy to evolve.
 
@@ -73,7 +73,7 @@ export interface MicrobitWebUSBConnectionOptions {
   deviceSelectionMode?: DeviceSelectionMode;
 }
 
-export interface MicrobitWebUSBConnection
+export interface MicrobitUSBConnection
   extends DeviceConnection<SerialConnectionEventMap> {
   /**
    * Gets micro:bit deviceId.
@@ -87,14 +87,6 @@ export interface MicrobitWebUSBConnection
    */
   setRequestDeviceExclusionFilters(exclusionFilters: USBDeviceFilter[]): void;
 
-  /**
-   * Flash the micro:bit.
-   *
-   * @param dataSource The data to use.
-   * @param options Flash options and progress callback.
-   * @throws {DeviceError} On flash failure. The error.code property indicates the failure type.
-   * @throws {FlashDataError} If data preparation fails.
-   */
   flash(dataSource: FlashDataSource, options: FlashOptions): Promise<void>;
 
   /**
@@ -113,16 +105,16 @@ export interface MicrobitWebUSBConnection
 /**
  * A WebUSB connection factory.
  */
-export const createWebUSBConnection = (
-  options?: MicrobitWebUSBConnectionOptions,
-): MicrobitWebUSBConnection => new MicrobitWebUSBConnectionImpl(options);
+export const createUSBConnection = (
+  options?: MicrobitUSBConnectionOptions,
+): MicrobitUSBConnection => new MicrobitUSBConnectionImpl(options);
 
 /**
  * A WebUSB connection to a micro:bit device.
  */
-class MicrobitWebUSBConnectionImpl
+class MicrobitUSBConnectionImpl
   extends TypedEventTarget<DeviceConnectionEventMap & SerialConnectionEventMap>
-  implements MicrobitWebUSBConnection
+  implements MicrobitUSBConnection
 {
   status: ConnectionStatus = ConnectionStatus.NO_AUTHORIZED_DEVICE;
 
@@ -205,7 +197,7 @@ class MicrobitWebUSBConnectionImpl
     serialdata: 0,
   };
 
-  constructor(options: MicrobitWebUSBConnectionOptions = {}) {
+  constructor(options: MicrobitUSBConnectionOptions = {}) {
     super();
     this.logging = options.logging || new ConsoleLogging();
     this.deviceSelectionMode =

--- a/packages/microbit-connection/typedoc.json
+++ b/packages/microbit-connection/typedoc.json
@@ -4,7 +4,13 @@
     "micro:bit tech site": "https://tech.microbit.org",
     "GitHub": "https://github.com/microbit-foundation/microbit-connection"
   },
-  "entryPoints": ["./src/index.ts"],
+  "entryPoints": [
+    "./src/index.ts",
+    "./src/bluetooth-entrypoint.ts",
+    "./src/usb-entrypoint.ts",
+    "./src/universal-hex-entrypoint.ts",
+    "./src/radio-bridge-entrypoint.ts"
+  ],
   "out": "./docs/build",
   "readme": "../../README.md",
   "headings": {


### PR DESCRIPTION
Separate USB and Bluetooth entrypoints (breaking).

Restructure so USB consumers who don't use createUniversalHexFlashDataSource no
longer pull in @microbit/microbit-universal-hex.

Rename createWebBluetoothConnection to createBluetoothConnection (and
MicrobitWebBluetoothConnection to MicrobitBluetoothConnection) as it now
covers native platforms, not just Web Bluetooth.

Add `sideEffects: false` to package.json.

Updated README with entrypoints documentation and platform support table