### PR TITLE
Skip partial flash if we get zero hash value

### DIFF
--- a/packages/microbit-connection/src/flashing/flashing-partial.ts
+++ b/packages/microbit-connection/src/flashing/flashing-partial.ts
@@ -102,6 +102,11 @@ const partialFlashInternal = async (
     return PartialFlashResult.AttemptFullFlash;
   }
 
+  if (/^0+$/.test(deviceDalRegion.hash) || /^0+$/.test(deviceCodeRegion.hash)) {
+    connection.log("Device reported zero hash, partial flash not reliable");
+    return PartialFlashResult.AttemptFullFlash;
+  }
+
   progress(ProgressStage.PartialFlashing);
 
   const fileCodeRegion = findMakeCodeRegionInMemoryMap(

--- a/packages/microbit-connection/src/flashing/flashing-partial.ts
+++ b/packages/microbit-connection/src/flashing/flashing-partial.ts
@@ -103,7 +103,7 @@ const partialFlashInternal = async (
   }
 
   if (/^0+$/.test(deviceDalRegion.hash) || /^0+$/.test(deviceCodeRegion.hash)) {
-    connection.log("Device reported zero hash, partial flash not reliable");
+    connection.log("Device reported zero hash, skipping partial flash");
     return PartialFlashResult.AttemptFullFlash;
   }
 


### PR DESCRIPTION
The hash isn't populated for builds without the MakeCode magic so we don't want to determine two such builds are the same incorrectly. In practice it's unlikely these builds will have a PF service but still.