### PR TITLE
Use DAPLink vendor command for serial

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "npm run dev -w @microbit/microbit-connection-demo",
     "test": "npm run test -w @microbit/microbit-connection",
     "ci": "npm run build && npm run test && npm run format:check",
-    "format": "prettier --write packages/*/src",
+    "format": "prettier --write --list-different packages/*/src",
     "format:check": "prettier --check packages/*/src",
     "docs": "npm run docs -w @microbit/microbit-connection"
   },

--- a/packages/microbit-connection/src/board-serial-info.test.ts
+++ b/packages/microbit-connection/src/board-serial-info.test.ts
@@ -45,8 +45,6 @@ describe("BoardSerialInfo", () => {
       hic: "00097969",
     });
 
-    expect(log.mock.calls).toEqual([
-      ["USB serial number unexpected length: 45"],
-    ]);
+    expect(log.mock.calls).toEqual([["Serial number unexpected length: 45"]]);
   });
 });

--- a/packages/microbit-connection/src/board-serial-info.ts
+++ b/packages/microbit-connection/src/board-serial-info.ts
@@ -11,18 +11,23 @@ export class BoardSerialInfo {
     public familyId: string,
     public hic: string,
   ) {}
-  static parse(device: USBDevice, log: (msg: string) => void) {
-    const serial = device.serialNumber;
-    if (!serial) {
-      throw new Error("Could not detected ID from connected board.");
-    }
+
+  static fromSerial(serial: string, log: (msg: string) => void) {
     if (serial.length !== 48) {
-      log(`USB serial number unexpected length: ${serial.length}`);
+      log(`Serial number unexpected length: ${serial.length}`);
     }
     const id = serial.substring(0, 4);
     const familyId = serial.substring(4, 8);
     const hic = serial.slice(-8);
     return new BoardSerialInfo(BoardId.parse(id), familyId, hic);
+  }
+
+  static parse(device: USBDevice, log: (msg: string) => void) {
+    const serial = device.serialNumber;
+    if (!serial) {
+      throw new Error("Could not detected ID from connected board.");
+    }
+    return BoardSerialInfo.fromSerial(serial, log);
   }
 
   eq(other: BoardSerialInfo) {

--- a/packages/microbit-connection/src/constants.ts
+++ b/packages/microbit-connection/src/constants.ts
@@ -28,6 +28,13 @@ export const DapCmd = {
   // Many more.
 };
 
+// DAPLink vendor commands
+// https://github.com/ARMmbed/DAPLink/blob/main/source/daplink/cmsis-dap/daplink_vendor_commands.h
+export const DapLinkVendorCmd = {
+  /** Read the DAPLink unique ID (same string as USB serial number). */
+  READ_UNIQUE_ID: 0x80,
+};
+
 export const Csw = {
   CSW_SIZE: 0x00000007,
   CSW_SIZE32: 0x00000002,

--- a/packages/microbit-connection/src/device.ts
+++ b/packages/microbit-connection/src/device.ts
@@ -47,7 +47,7 @@ export type DeviceErrorCode =
    */
   | "timeout-error"
   /**
-   * This is the fallback error case suggesting that the user reconnects their device.
+   * This is the fallback error case suggesting that the user physically reconnects their device.
    */
   | "reconnect-microbit"
   /**

--- a/packages/microbit-connection/src/usb-device-wrapper.ts
+++ b/packages/microbit-connection/src/usb-device-wrapper.ts
@@ -6,28 +6,29 @@
 import * as dapjs from "dapjs";
 // dapjs import faff needed for use from Node such as Vitest https://github.com/ARMmbed/dapjs/issues/118
 import type { CortexM, DAPLink, WebUSB } from "dapjs";
-const {
-  CortexM: CortexMValue,
-  DAPLink: DAPLinkValue,
-  WebUSB: WebUSBValue,
-} = dapjs;
-import { Logging } from "./logging.js";
+import { BoardSerialInfo } from "./board-serial-info.js";
 import {
   ApReg,
   CortexSpecialReg,
   Csw,
   DapCmd,
+  DapLinkVendorCmd,
   DapVal,
   FICR,
 } from "./constants.js";
+import { DeviceError } from "./device.js";
+import { Logging } from "./logging.js";
 import {
   apReg,
   bufferConcat,
   CoreRegister,
   regRequest,
 } from "./usb-partial-flashing-utils.js";
-import { BoardSerialInfo } from "./board-serial-info.js";
-import { DeviceError } from "./device.js";
+const {
+  CortexM: CortexMValue,
+  DAPLink: DAPLinkValue,
+  WebUSB: WebUSBValue,
+} = dapjs;
 
 export class DAPWrapper {
   transport: WebUSB;
@@ -38,6 +39,7 @@ export class DAPWrapper {
   _numPages: number | undefined;
   _deviceId: number | undefined;
 
+  private _boardSerialInfo: BoardSerialInfo | undefined;
   private loggedBoardSerialInfo: BoardSerialInfo | undefined;
 
   private initialConnectionComplete: boolean = false;
@@ -85,10 +87,10 @@ export class DAPWrapper {
   }
 
   get boardSerialInfo(): BoardSerialInfo {
-    return BoardSerialInfo.parse(
-      this.device,
-      this.logging.log.bind(this.logging),
-    );
+    if (!this._boardSerialInfo) {
+      throw new Error("boardSerialInfo not available until connected");
+    }
+    return this._boardSerialInfo;
   }
 
   // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L119
@@ -104,6 +106,27 @@ export class DAPWrapper {
     }
 
     await this.connectDaplink();
+
+    // Read the serial/unique ID via DAPLink vendor command 0x80.
+    // Chrome may anonymize USBDevice.serialNumber for anti-fingerprinting
+    // (https://github.com/microbit-foundation/microbit-connection/issues/57)
+    // so we read it via the DAP protocol instead.
+    const dapSerial = await this.readDaplinkSerial();
+    if (dapSerial) {
+      this._boardSerialInfo = BoardSerialInfo.fromSerial(
+        dapSerial,
+        this.logging.log.bind(this.logging),
+      );
+    } else {
+      this.logging.log(
+        "Failed to read serial via DAP vendor command, falling back to USB serial number (may be affected by anti-fingerprinting)",
+      );
+      this._boardSerialInfo = BoardSerialInfo.parse(
+        this.device,
+        this.logging.log.bind(this.logging),
+      );
+    }
+
     await this.cortexM.connect();
 
     this.logging.event({
@@ -243,6 +266,36 @@ export class DAPWrapper {
     }
 
     throw lastError || new Error("Connection failed after retries");
+  }
+
+  /**
+   * Read the DAPLink unique ID via vendor command 0x80.
+   * This returns the same 48-char hex string as the USB serial number
+   * but isn't affected by browser anti-fingerprinting.
+   */
+  private async readDaplinkSerial(): Promise<string | undefined> {
+    try {
+      const buf = await this.send([DapLinkVendorCmd.READ_UNIQUE_ID]);
+      if (buf[0] !== DapLinkVendorCmd.READ_UNIQUE_ID) {
+        this.logging.log(
+          `Unexpected response to vendor command: 0x${buf[0].toString(16)}`,
+        );
+        return undefined;
+      }
+      const length = buf[1];
+      if (length === 0) {
+        return undefined;
+      }
+      // The response is [cmd, length, ...ascii_bytes].
+      // DAPLink uses strlen() for the length so no null terminator is included.
+      const bytes = buf.subarray(2, 2 + length);
+      return new TextDecoder().decode(bytes);
+    } catch (e) {
+      this.logging.log(
+        `Error reading DAPLink serial: ${e instanceof Error ? e.message : e}`,
+      );
+      return undefined;
+    }
   }
 
   async startSerial(listener: (data: string) => void): Promise<void> {


### PR DESCRIPTION
In Brave we can fail to parse the serial and therefore to tell the board version (it anonomises the device serial number) and we need this information to flash the correct hex.

This matches MakeCode's approach.

I confirmed that identical serials are found in Chrome for V1 and V2 via this and the old method.

I don't think the fallback should come into play but leaving it for now. This feature has been in DAPLink since WebUSB support has been in DAPLink.

See https://github.com/microbit-foundation/microbit-connection/issues/57