### PR TITLE
Breaking: Switch to throwing DeviceError when not connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ console.log("Connection status: ", connectionStatus);
 
 For more examples see the [web demo source](apps/demo/src/demo.ts) and the [Capacitor demo source](apps/capacitor/src/).
 
+### Error handling
+
+Methods that interact with device features (reading sensors, writing to LEDs, serial communication, etc.) throw a {@link @microbit/microbit-connection!DeviceError | DeviceError} with code `"not-connected"` if called without an active connection:
+
+```ts
+import { DeviceError } from "@microbit/microbit-connection";
+
+try {
+  const data = await bluetooth.getAccelerometerData();
+} catch (e) {
+  if (e instanceof DeviceError && e.code === "not-connected") {
+    console.log("Connect to a micro:bit first");
+  }
+}
+```
+
 ## Known limitations
 
 ### Bluetooth

--- a/packages/microbit-connection/src/bluetooth.ts
+++ b/packages/microbit-connection/src/bluetooth.ts
@@ -25,6 +25,7 @@ import {
   DeviceConnectionEventMap,
   DeviceError,
   FlashDataError,
+  assertConnected,
   FlashDataSource,
   FlashOptions,
   ProgressCallback,
@@ -72,21 +73,24 @@ export interface MicrobitBluetoothConnection
   /**
    * Gets micro:bit accelerometer data.
    *
-   * @returns accelerometer data or undefined if there is no connection.
+   * @returns accelerometer data.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
-  getAccelerometerData(): Promise<AccelerometerData | undefined>;
+  getAccelerometerData(): Promise<AccelerometerData>;
 
   /**
    * Gets micro:bit accelerometer period.
    *
-   * @returns accelerometer period or undefined if there is no connection.
+   * @returns accelerometer period.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
-  getAccelerometerPeriod(): Promise<number | undefined>;
+  getAccelerometerPeriod(): Promise<number>;
 
   /**
    * Sets micro:bit accelerometer period.
    *
    * @param value The accelerometer period.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
   setAccelerometerPeriod(value: number): Promise<void>;
 
@@ -94,6 +98,7 @@ export interface MicrobitBluetoothConnection
    * Sets micro:bit LED text.
    *
    * @param text The text displayed on micro:bit LED.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
   setLedText(text: string): Promise<void>;
 
@@ -101,13 +106,15 @@ export interface MicrobitBluetoothConnection
    * Gets micro:bit LED scrolling delay.
    *
    * @returns LED scrolling delay in milliseconds.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
-  getLedScrollingDelay(): Promise<number | undefined>;
+  getLedScrollingDelay(): Promise<number>;
 
   /**
    * Sets micro:bit LED scrolling delay.
    *
    * @param delayInMillis LED scrolling delay in milliseconds.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
   setLedScrollingDelay(delayInMillis: number): Promise<void>;
 
@@ -115,13 +122,15 @@ export interface MicrobitBluetoothConnection
    * Gets micro:bit LED matrix.
    *
    * @returns a boolean matrix representing the micro:bit LED display.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
-  getLedMatrix(): Promise<LedMatrix | undefined>;
+  getLedMatrix(): Promise<LedMatrix>;
 
   /**
    * Sets micro:bit LED matrix.
    *
    * @param matrix an boolean matrix representing the micro:bit LED display.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
   setLedMatrix(matrix: LedMatrix): Promise<void>;
 
@@ -129,32 +138,38 @@ export interface MicrobitBluetoothConnection
    * Gets micro:bit magnetometer data.
    *
    * @returns magnetometer data.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
-  getMagnetometerData(): Promise<MagnetometerData | undefined>;
+  getMagnetometerData(): Promise<MagnetometerData>;
 
   /**
    * Gets micro:bit magnetometer bearing.
    *
    * @returns magnetometer bearing.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
-  getMagnetometerBearing(): Promise<number | undefined>;
+  getMagnetometerBearing(): Promise<number>;
 
   /**
    * Gets micro:bit magnetometer period.
    *
    * @returns magnetometer period.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
-  getMagnetometerPeriod(): Promise<number | undefined>;
+  getMagnetometerPeriod(): Promise<number>;
 
   /**
    * Sets micro:bit magnetometer period.
    *
    * @param value magnetometer period.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
   setMagnetometerPeriod(value: number): Promise<void>;
 
   /**
    * Triggers micro:bit magnetometer calibration.
+   *
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
   triggerMagnetometerCalibration(): Promise<void>;
 
@@ -162,6 +177,7 @@ export interface MicrobitBluetoothConnection
    * Write UART messages.
    *
    * @param data UART message.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
   uartWrite(data: Uint8Array): Promise<void>;
 
@@ -193,6 +209,11 @@ class MicrobitBluetoothConnectionImpl
   private logging: Logging;
   private deviceBondState: DeviceBondState;
   private connection: BluetoothDeviceWrapper | undefined;
+
+  /**
+   * Cached device property that persists across reconnections until clearDevice.
+   */
+  private cachedBoardVersion: BoardVersion | undefined;
 
   private nameFilter: string | undefined;
   private deferredUpdatesPreviousStatus: ConnectionStatus | undefined;
@@ -290,8 +311,9 @@ class MicrobitBluetoothConnectionImpl
     }
   }
 
-  getBoardVersion(): BoardVersion | undefined {
-    return this.connection?.boardVersion;
+  getBoardVersion(): BoardVersion {
+    assertConnected(this.cachedBoardVersion);
+    return this.cachedBoardVersion;
   }
 
   async connect(options?: ConnectOptions): Promise<void> {
@@ -325,6 +347,7 @@ class MicrobitBluetoothConnectionImpl
     }
 
     await this.connection.connect(options);
+    this.cachedBoardVersion = this.connection.boardVersion;
   }
 
   async disconnect(): Promise<void> {
@@ -359,15 +382,15 @@ class MicrobitBluetoothConnectionImpl
   }
 
   serialWrite(data: string): Promise<void> {
-    if (this.connection) {
-      // TODO
-    }
+    assertConnected(this.connection);
+    // TODO
     return Promise.resolve();
   }
 
   async clearDevice(): Promise<void> {
     await this.disconnect();
     this.device = undefined;
+    this.cachedBoardVersion = undefined;
     this.setStatus(ConnectionStatus.NO_AUTHORIZED_DEVICE);
   }
 
@@ -413,60 +436,74 @@ class MicrobitBluetoothConnectionImpl
     }
   }
 
-  async getAccelerometerData(): Promise<AccelerometerData | undefined> {
-    return this.connection?.accelerometer.getData();
+  async getAccelerometerData(): Promise<AccelerometerData> {
+    assertConnected(this.connection);
+    return this.connection.accelerometer.getData();
   }
 
-  async getAccelerometerPeriod(): Promise<number | undefined> {
-    return this.connection?.accelerometer.getPeriod();
+  async getAccelerometerPeriod(): Promise<number> {
+    assertConnected(this.connection);
+    return this.connection.accelerometer.getPeriod();
   }
 
   async setAccelerometerPeriod(value: number): Promise<void> {
-    return this.connection?.accelerometer.setPeriod(value);
+    assertConnected(this.connection);
+    return this.connection.accelerometer.setPeriod(value);
   }
 
   async setLedText(text: string): Promise<void> {
-    return this.connection?.led.setText(text);
+    assertConnected(this.connection);
+    return this.connection.led.setText(text);
   }
 
-  async getLedScrollingDelay(): Promise<number | undefined> {
-    return this.connection?.led.getScrollingDelay();
+  async getLedScrollingDelay(): Promise<number> {
+    assertConnected(this.connection);
+    return this.connection.led.getScrollingDelay();
   }
 
   async setLedScrollingDelay(delayInMillis: number): Promise<void> {
-    await this.connection?.led.setScrollingDelay(delayInMillis);
+    assertConnected(this.connection);
+    await this.connection.led.setScrollingDelay(delayInMillis);
   }
 
-  async getLedMatrix(): Promise<LedMatrix | undefined> {
-    return await this.connection?.led.getLedMatrix();
+  async getLedMatrix(): Promise<LedMatrix> {
+    assertConnected(this.connection);
+    return await this.connection.led.getLedMatrix();
   }
 
   async setLedMatrix(matrix: LedMatrix): Promise<void> {
-    await this.connection?.led.setLedMatrix(matrix);
+    assertConnected(this.connection);
+    await this.connection.led.setLedMatrix(matrix);
   }
 
-  async getMagnetometerData(): Promise<MagnetometerData | undefined> {
-    return this.connection?.magnetometer.getData();
+  async getMagnetometerData(): Promise<MagnetometerData> {
+    assertConnected(this.connection);
+    return this.connection.magnetometer.getData();
   }
 
-  async getMagnetometerPeriod(): Promise<number | undefined> {
-    return this.connection?.magnetometer.getPeriod();
+  async getMagnetometerPeriod(): Promise<number> {
+    assertConnected(this.connection);
+    return this.connection.magnetometer.getPeriod();
   }
 
   async setMagnetometerPeriod(value: number): Promise<void> {
-    return this.connection?.magnetometer.setPeriod(value);
+    assertConnected(this.connection);
+    return this.connection.magnetometer.setPeriod(value);
   }
 
-  async getMagnetometerBearing(): Promise<number | undefined> {
-    return this.connection?.magnetometer.getBearing();
+  async getMagnetometerBearing(): Promise<number> {
+    assertConnected(this.connection);
+    return this.connection.magnetometer.getBearing();
   }
 
   async triggerMagnetometerCalibration(): Promise<void> {
-    await this.connection?.magnetometer.triggerCalibration();
+    assertConnected(this.connection);
+    await this.connection.magnetometer.triggerCalibration();
   }
 
   async uartWrite(data: Uint8Array): Promise<void> {
-    await this.connection?.uart.writeData(data);
+    assertConnected(this.connection);
+    await this.connection.uart.writeData(data);
   }
 
   /**

--- a/packages/microbit-connection/src/device.ts
+++ b/packages/microbit-connection/src/device.ts
@@ -51,6 +51,10 @@ export type DeviceErrorCode =
    */
   | "reconnect-microbit"
   /**
+   * An operation was attempted that requires an active connection.
+   */
+  | "not-connected"
+  /**
    * Error occured during serial or bluetooth communication.
    */
   | "background-comms-error"
@@ -167,6 +171,18 @@ export class DeviceError extends Error {
   constructor({ code, message }: { code: DeviceErrorCode; message?: string }) {
     super(message);
     this.code = code;
+  }
+}
+
+/**
+ * Asserts that a connection is active, throwing a {@link DeviceError}
+ * with code `"not-connected"` if it is not.
+ */
+export function assertConnected<T>(
+  connection: T | undefined,
+): asserts connection is T {
+  if (!connection) {
+    throw new DeviceError({ code: "not-connected", message: "Not connected" });
   }
 }
 
@@ -331,9 +347,13 @@ export interface DeviceConnection<M extends ValueIsEvent<M>>
   /**
    * Get the board version.
    *
-   * @returns the board version or undefined if there is no connection.
+   * Cached after the first successful connection until {@link clearDevice}
+   * is called, so remains available after disconnection.
+   *
+   * @returns the board version.
+   * @throws {DeviceError} with code `not-connected` if no device has been connected.
    */
-  getBoardVersion(): BoardVersion | undefined;
+  getBoardVersion(): BoardVersion;
 
   /**
    * Disconnect from the device.
@@ -343,10 +363,9 @@ export interface DeviceConnection<M extends ValueIsEvent<M>>
   /**
    * Write serial data to the device.
    *
-   * Does nothing if there is no connection.
-   *
    * @param data The data to write.
    * @returns A promise that resolves when the write is complete.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
   serialWrite(data: string): Promise<void>;
 

--- a/packages/microbit-connection/src/index.ts
+++ b/packages/microbit-connection/src/index.ts
@@ -23,6 +23,7 @@ import {
   FlashOptions,
   ProgressCallback,
   ProgressStage,
+  assertConnected,
 } from "./device.js";
 import { TypedEventTarget } from "./events.js";
 import { LedMatrix } from "./led.js";
@@ -48,6 +49,7 @@ export {
   DeviceConnectionEventMap,
   DeviceError,
   FlashDataError,
+  assertConnected,
   FlashEvent,
   ProgressStage,
   SerialConnectionEventMap,

--- a/packages/microbit-connection/src/usb-device-wrapper.ts
+++ b/packages/microbit-connection/src/usb-device-wrapper.ts
@@ -16,7 +16,7 @@ import {
   DapVal,
   FICR,
 } from "./constants.js";
-import { DeviceError } from "./device.js";
+import { DeviceError, assertConnected } from "./device.js";
 import { Logging } from "./logging.js";
 import {
   apReg,
@@ -87,9 +87,7 @@ export class DAPWrapper {
   }
 
   get boardSerialInfo(): BoardSerialInfo {
-    if (!this._boardSerialInfo) {
-      throw new Error("boardSerialInfo not available until connected");
-    }
+    assertConnected(this._boardSerialInfo);
     return this._boardSerialInfo;
   }
 

--- a/packages/microbit-connection/src/usb-radio-bridge.ts
+++ b/packages/microbit-connection/src/usb-radio-bridge.ts
@@ -110,7 +110,7 @@ class MicrobitRadioBridgeConnectionImpl
     this.status = this.statusFromDelegate();
   }
 
-  getBoardVersion(): BoardVersion | undefined {
+  getBoardVersion(): BoardVersion {
     return this.delegate.getBoardVersion();
   }
 
@@ -386,7 +386,11 @@ class RadioBridgeSerialSession {
     if (disconnect) {
       await this.delegate.disconnect();
     }
-    await this.delegate.softwareReset();
+    try {
+      await this.delegate.softwareReset();
+    } catch {
+      // May already be disconnected.
+    }
   }
 
   private async sendCmdWaitResponse(

--- a/packages/microbit-connection/src/usb.ts
+++ b/packages/microbit-connection/src/usb.ts
@@ -21,6 +21,7 @@ import {
   FlashOptions,
   ProgressCallback,
   ProgressStage,
+  assertConnected,
 } from "./device.js";
 import { TypedEventTarget } from "./events.js";
 import { Logging, ConsoleLogging } from "./logging.js";
@@ -90,9 +91,13 @@ export interface MicrobitUSBConnection
   /**
    * Gets micro:bit deviceId.
    *
-   * @returns the device id or undefined if there is no connection.
+   * Cached after the first successful connection until {@link clearDevice}
+   * is called, so remains available after disconnection.
+   *
+   * @returns the device id.
+   * @throws {DeviceError} with code `not-connected` if no device has been connected.
    */
-  getDeviceId(): number | undefined;
+  getDeviceId(): number;
 
   /**
    * Sets device request exclusion filters.
@@ -140,6 +145,12 @@ class MicrobitUSBConnectionImpl
    * The connection to the device.
    */
   private connection: DAPWrapper | undefined;
+
+  /**
+   * Cached device properties that persist across reconnections until clearDevice.
+   */
+  private cachedBoardVersion: BoardVersion | undefined;
+  private cachedDeviceId: number | undefined;
 
   /**
    * Whether the serial read loop is running.
@@ -274,16 +285,18 @@ class MicrobitUSBConnectionImpl
     });
   }
 
-  getDeviceId(): number | undefined {
-    return this.connection?.deviceId;
+  getDeviceId(): number {
+    assertConnected(this.cachedDeviceId);
+    return this.cachedDeviceId;
   }
 
   getDevice(): USBDevice | undefined {
     return this.device;
   }
 
-  getBoardVersion(): BoardVersion | undefined {
-    return this.connection?.boardSerialInfo?.id.toBoardVersion();
+  getBoardVersion(): BoardVersion {
+    assertConnected(this.cachedBoardVersion);
+    return this.cachedBoardVersion;
   }
 
   async flash(
@@ -479,25 +492,27 @@ class MicrobitUSBConnectionImpl
   }
 
   serialWrite(data: string): Promise<void> {
+    assertConnected(this.connection);
+    const connection = this.connection;
     return this.withEnrichedErrors(async () => {
-      if (this.connection) {
-        // Using WebUSB/DAPJs we're limited to 64 byte packet size with a two byte header.
-        // https://github.com/microbit-foundation/python-editor-v3/issues/215
-        const maxSerialWrite = 62;
-        let start = 0;
-        while (start < data.length) {
-          const end = Math.min(start + maxSerialWrite, data.length);
-          const chunkData = data.slice(start, end);
-          await this.connection.daplink.serialWrite(chunkData);
-          start = end;
-        }
+      // Using WebUSB/DAPJs we're limited to 64 byte packet size with a two byte header.
+      // https://github.com/microbit-foundation/python-editor-v3/issues/215
+      const maxSerialWrite = 62;
+      let start = 0;
+      while (start < data.length) {
+        const end = Math.min(start + maxSerialWrite, data.length);
+        const chunkData = data.slice(start, end);
+        await connection.daplink.serialWrite(chunkData);
+        start = end;
       }
     });
   }
 
   async softwareReset(): Promise<void> {
+    assertConnected(this.connection);
+    const connection = this.connection;
     return this.serialStateChangeQueue.add(
-      async () => await this.connection?.softwareReset(),
+      async () => await connection.softwareReset(),
     );
   }
 
@@ -512,6 +527,8 @@ class MicrobitUSBConnectionImpl
   async clearDevice(): Promise<void> {
     await this.disconnect();
     this.device = undefined;
+    this.cachedBoardVersion = undefined;
+    this.cachedDeviceId = undefined;
     this.setStatus(ConnectionStatus.NO_AUTHORIZED_DEVICE);
   }
 
@@ -530,6 +547,15 @@ class MicrobitUSBConnectionImpl
       reportProgress(ProgressStage.Connecting);
       await withTimeout(this.connection.reconnectAsync(), 10_000);
     }
+    // Cache device properties so they survive disconnection.
+    this.cachedDeviceId = this.connection!.deviceId;
+    try {
+      this.cachedBoardVersion =
+        this.connection!.boardSerialInfo.id.toBoardVersion();
+    } catch {
+      // boardSerialInfo may not be available (e.g. in tests).
+    }
+
     if (this.hasSerialEventListeners() && !this.flashing) {
       this.startSerialInternal();
     }


### PR DESCRIPTION
Introduce a new code for the purpose.

Previously we returned undefined in scenarios where you call the method either before connection or when unexpectedly disconnected. This can lead to errors being ignored or knock-on errors because you "know" you're connected but disconnects can happen at arbitrary points. Better to require the caller to handle an error.