### PR TITLE
Breaking: Replace EventTarget with custom typed event system

### DIFF
--- a/apps/capacitor/src/hooks/use-connection.ts
+++ b/apps/capacitor/src/hooks/use-connection.ts
@@ -1,8 +1,7 @@
 import {
   AccelerometerData,
-  AccelerometerDataEvent,
   ConnectionStatus,
-  ConnectionStatusEvent,
+  ConnectionStatusChange,
 } from "@microbit/microbit-connection";
 import { type MicrobitBluetoothConnection } from "@microbit/microbit-connection/bluetooth";
 import { createContext, useContext, useEffect, useState } from "react";
@@ -23,7 +22,7 @@ export const useConnection = () => {
 
   // Listen to connection status.
   useEffect(() => {
-    const statusListener = (e: ConnectionStatusEvent) => {
+    const statusListener = (e: ConnectionStatusChange) => {
       setStatus(e.status);
     };
     connection.addEventListener("status", statusListener);
@@ -38,8 +37,8 @@ export const useConnection = () => {
       setAccelerometerData(undefined);
       return;
     }
-    const accelerometerListener = (e: AccelerometerDataEvent) => {
-      setAccelerometerData(e.data);
+    const accelerometerListener = (data: AccelerometerData) => {
+      setAccelerometerData(data);
     };
     connection.addEventListener(
       "accelerometerdatachanged",

--- a/apps/demo/src/demo.ts
+++ b/apps/demo/src/demo.ts
@@ -5,14 +5,14 @@
  */
 import crelt from "crelt";
 import {
-  AccelerometerDataEvent,
-  BackgroundErrorEvent,
-  ButtonEvent,
+  AccelerometerData,
+  BackgroundErrorData,
+  ButtonData,
   ConnectionStatus,
-  ConnectionStatusEvent,
-  MagnetometerDataEvent,
-  SerialDataEvent,
-  UARTDataEvent,
+  ConnectionStatusChange,
+  MagnetometerData,
+  SerialData,
+  UartData,
 } from "@microbit/microbit-connection";
 import {
   createBluetoothConnection,
@@ -212,11 +212,11 @@ const createConnectSection = (): Section => {
   const displayStatus = (status: ConnectionStatus) => {
     statusParagraph.textContent = status.toString();
   };
-  const handleDisplayStatusChange = (event: ConnectionStatusEvent) => {
+  const handleDisplayStatusChange = (event: ConnectionStatusChange) => {
     displayStatus(event.status);
   };
-  const backgroundErrorListener = (event: BackgroundErrorEvent) => {
-    console.error("Handled error:", event.errorMessage);
+  const backgroundErrorListener = (event: BackgroundErrorData) => {
+    console.error("Handled error:", event.message);
   };
   (connection as any).addEventListener("status", handleDisplayStatusChange);
   (connection as any).addEventListener(
@@ -278,7 +278,7 @@ const createSerialSection = (): Section => {
   }
 
   let data = "";
-  const serialDataListener = (event: SerialDataEvent) => {
+  const serialDataListener = (event: SerialData) => {
     for (const char of event.data) {
       if (char === "\n") {
         console.log(data);
@@ -329,7 +329,7 @@ const createUARTSection = (): Section => {
     return {};
   }
 
-  const uartDataListener = (event: UARTDataEvent) => {
+  const uartDataListener = (event: UartData) => {
     const value = new TextDecoder().decode(event.value);
     console.log(value);
   };
@@ -401,8 +401,8 @@ const createAccelerometerSection = (): Section => {
     return {};
   }
   const statusParagraph = crelt("p");
-  const listener = (e: AccelerometerDataEvent) => {
-    statusParagraph.innerText = JSON.stringify(e.data);
+  const listener = (data: AccelerometerData) => {
+    statusParagraph.innerText = JSON.stringify(data);
   };
   let period = "";
   const periodInput = crelt("input", {
@@ -448,10 +448,9 @@ const createAccelerometerSection = (): Section => {
             "button",
             {
               onclick: async () => {
-                period =
-                  (
-                    await accelerometerConnection.getAccelerometerPeriod()
-                  )?.toString() ?? "";
+                period = (
+                  await accelerometerConnection.getAccelerometerPeriod()
+                ).toString();
                 periodInput.value = period;
               },
             },
@@ -488,8 +487,8 @@ const createMagnetometerSection = (): Section => {
     return {};
   }
   const statusParagraph = crelt("p");
-  const listener = (e: MagnetometerDataEvent) => {
-    statusParagraph.innerText = JSON.stringify(e.data);
+  const listener = (data: MagnetometerData) => {
+    statusParagraph.innerText = JSON.stringify(data);
   };
   let period = "";
   const periodInput = crelt("input", {
@@ -536,10 +535,9 @@ const createMagnetometerSection = (): Section => {
             "button",
             {
               onclick: async () => {
-                period =
-                  (
-                    await magnetometerConnection.getMagnetometerPeriod()
-                  )?.toString() ?? "";
+                period = (
+                  await magnetometerConnection.getMagnetometerPeriod()
+                ).toString();
                 periodInput.value = period;
               },
             },
@@ -576,7 +574,7 @@ const createMagnetometerSection = (): Section => {
               onclick: async () => {
                 const bearing =
                   await magnetometerConnection.getMagnetometerBearing();
-                bearingParagraph.textContent = `Bearing: ${bearing ?? 0} degrees`;
+                bearingParagraph.textContent = `Bearing: ${bearing} degrees`;
               },
             },
             "Get bearing",
@@ -604,8 +602,8 @@ const createButtonSection = (
     return {};
   }
   const statusParagraph = crelt("p");
-  const buttonStateListener = (e: ButtonEvent) => {
-    statusParagraph.innerText = e.state.toString();
+  const buttonStateListener = (data: ButtonData) => {
+    statusParagraph.innerText = data.state.toString();
   };
   const dom = crelt(
     "section",

--- a/packages/microbit-connection/src/accelerometer-service.ts
+++ b/packages/microbit-connection/src/accelerometer-service.ts
@@ -1,12 +1,11 @@
 import { BleClient } from "@capacitor-community/bluetooth-le";
-import { AccelerometerData, AccelerometerDataEvent } from "./accelerometer.js";
+import { AccelerometerData } from "./accelerometer.js";
 import { Service } from "./bluetooth-device-wrapper.js";
 import {
   TypedServiceEvent,
   TypedServiceEventDispatcher,
 } from "./service-events.js";
 import { profile } from "./bluetooth-profile.js";
-import { BackgroundErrorEvent } from "./device.js";
 
 export class AccelerometerService implements Service {
   uuid = profile.accelerometer.id;
@@ -83,17 +82,14 @@ export class AccelerometerService implements Service {
           characteristic,
           (value) => {
             const data = this.dataViewToData(value);
-            this.dispatchTypedEvent(
-              "accelerometerdatachanged",
-              new AccelerometerDataEvent(data),
-            );
+            this.dispatchTypedEvent("accelerometerdatachanged", data);
           },
         );
       } catch (e) {
-        this.dispatchTypedEvent(
-          "backgrounderror",
-          new BackgroundErrorEvent("Failed to start notifications", e),
-        );
+        this.dispatchTypedEvent("backgrounderror", {
+          message: "Failed to start notifications",
+          error: e,
+        });
       }
     }
   }
@@ -109,10 +105,10 @@ export class AccelerometerService implements Service {
           characteristic,
         );
       } catch (e) {
-        this.dispatchTypedEvent(
-          "backgrounderror",
-          new BackgroundErrorEvent("Failed to stop notifications", e),
-        );
+        this.dispatchTypedEvent("backgrounderror", {
+          message: "Failed to stop notifications",
+          error: e,
+        });
       }
     }
   }

--- a/packages/microbit-connection/src/accelerometer.ts
+++ b/packages/microbit-connection/src/accelerometer.ts
@@ -3,9 +3,3 @@ export interface AccelerometerData {
   y: number;
   z: number;
 }
-
-export class AccelerometerDataEvent extends Event {
-  constructor(public readonly data: AccelerometerData) {
-    super("accelerometerdatachanged");
-  }
-}

--- a/packages/microbit-connection/src/bluetooth.test.ts
+++ b/packages/microbit-connection/src/bluetooth.test.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { ConnectionStatus, ConnectionStatusEvent } from "./device.js";
+import { ConnectionStatus, ConnectionStatusChange } from "./device.js";
 import { createBluetoothConnection } from "./bluetooth.js";
 import { expect, vi, describe, it } from "vitest";
 
@@ -60,7 +60,7 @@ describe("Bluetooth connection status events", () => {
 
     expect(connection.status).toBe(ConnectionStatus.NO_AUTHORIZED_DEVICE);
 
-    const events: ConnectionStatusEvent[] = [];
+    const events: ConnectionStatusChange[] = [];
     connection.addEventListener("status", (e) => {
       events.push(e);
     });
@@ -82,7 +82,7 @@ describe("Bluetooth connection status events", () => {
     const statusBeforeFlash = connection.status;
     expect(statusBeforeFlash).toBe(ConnectionStatus.NO_AUTHORIZED_DEVICE);
 
-    const events: ConnectionStatusEvent[] = [];
+    const events: ConnectionStatusChange[] = [];
     connection.addEventListener("status", (e) => {
       events.push(e);
     });

--- a/packages/microbit-connection/src/bluetooth.ts
+++ b/packages/microbit-connection/src/bluetooth.ts
@@ -557,7 +557,11 @@ class MicrobitBluetoothConnectionImpl
 
         if (partialFlashResult === PartialFlashResult.AttemptFullFlash) {
           await fullFlash(connection, boardVersion, memoryMap, progress);
-        } else if (
+        }
+
+        this.dispatchEvent("flash");
+
+        if (
           partialFlashResult === PartialFlashResult.AlreadyUpToDate ||
           partialFlashResult === PartialFlashResult.Success
         ) {

--- a/packages/microbit-connection/src/bluetooth.ts
+++ b/packages/microbit-connection/src/bluetooth.ts
@@ -14,13 +14,10 @@ import {
 } from "./bluetooth-device-wrapper.js";
 import { profile } from "./bluetooth-profile.js";
 import {
-  AfterRequestDevice,
-  BeforeRequestDevice,
   BoardVersion,
   ConnectOptions,
   ConnectionAvailabilityStatus,
   ConnectionStatus,
-  ConnectionStatusEvent,
   DeviceConnection,
   DeviceConnectionEventMap,
   DeviceError,
@@ -336,7 +333,7 @@ class MicrobitBluetoothConnectionImpl
         device,
         this.logging,
         this.deviceBondState,
-        this.dispatchTypedEvent.bind(this),
+        this.dispatchEvent.bind(this),
         () => this.getActiveEvents() as Array<keyof ServiceConnectionEventMap>,
         {
           onConnecting: () => this.setStatus(ConnectionStatus.CONNECTING),
@@ -374,10 +371,10 @@ class MicrobitBluetoothConnectionImpl
     this.status = newStatus;
     this.log("Bluetooth connection status " + newStatus);
     if (this.deferredUpdatesPreviousStatus === undefined) {
-      this.dispatchTypedEvent(
-        "status",
-        new ConnectionStatusEvent(newStatus, previousStatus),
-      );
+      this.dispatchEvent("status", {
+        status: newStatus,
+        previousStatus,
+      });
     }
   }
 
@@ -418,7 +415,7 @@ class MicrobitBluetoothConnectionImpl
       await this.clearDevice();
     }
 
-    this.dispatchTypedEvent("beforerequestdevice", new BeforeRequestDevice());
+    this.dispatchEvent("beforerequestdevice");
     try {
       this.device = Capacitor.isNativePlatform()
         ? await this.requestDeviceNative(namePrefixes, signal)
@@ -432,7 +429,7 @@ class MicrobitBluetoothConnectionImpl
       }
       return this.device;
     } finally {
-      this.dispatchTypedEvent("afterrequestdevice", new AfterRequestDevice());
+      this.dispatchEvent("afterrequestdevice");
     }
   }
 
@@ -599,10 +596,10 @@ class MicrobitBluetoothConnectionImpl
     } finally {
       const previousStatus = this.deferredUpdatesPreviousStatus!;
       this.deferredUpdatesPreviousStatus = undefined;
-      this.dispatchTypedEvent(
-        "status",
-        new ConnectionStatusEvent(this.status, previousStatus),
-      );
+      this.dispatchEvent("status", {
+        status: this.status,
+        previousStatus,
+      });
     }
   }
 

--- a/packages/microbit-connection/src/button-service.ts
+++ b/packages/microbit-connection/src/button-service.ts
@@ -1,12 +1,10 @@
 import { BleClient } from "@capacitor-community/bluetooth-le";
 import { Service } from "./bluetooth-device-wrapper.js";
 import { profile } from "./bluetooth-profile.js";
-import { ButtonEvent, ButtonState } from "./buttons.js";
 import {
   TypedServiceEvent,
   TypedServiceEventDispatcher,
 } from "./service-events.js";
-import { BackgroundErrorEvent } from "./device.js";
 
 export class ButtonService implements Service {
   uuid = profile.button.id;
@@ -20,10 +18,6 @@ export class ButtonService implements Service {
     return ["buttonachanged", "buttonbchanged"];
   }
 
-  private dataViewToButtonState(dataView: DataView): ButtonState {
-    return dataView.getUint8(0);
-  }
-
   async startNotifications(type: TypedServiceEvent): Promise<void> {
     switch (type) {
       case "buttonachanged":
@@ -34,15 +28,18 @@ export class ButtonService implements Service {
             profile.button.id,
             this.characteristicForButtonEventType(type).id,
             (value) => {
-              const data = this.dataViewToButtonState(value);
-              this.dispatchTypedEvent(type, new ButtonEvent(type, data));
+              const state = value.getUint8(0);
+              this.dispatchTypedEvent(type, {
+                button: type === "buttonachanged" ? "A" : "B",
+                state,
+              });
             },
           );
         } catch (e) {
-          this.dispatchTypedEvent(
-            "backgrounderror",
-            new BackgroundErrorEvent("Failed to start notifications", e),
-          );
+          this.dispatchTypedEvent("backgrounderror", {
+            message: "Failed to start notifications",
+            error: e,
+          });
         }
       }
     }

--- a/packages/microbit-connection/src/buttons.ts
+++ b/packages/microbit-connection/src/buttons.ts
@@ -6,11 +6,7 @@ export enum ButtonState {
 
 export type ButtonEventType = "buttonachanged" | "buttonbchanged";
 
-export class ButtonEvent extends Event {
-  constructor(
-    type: ButtonEventType,
-    public readonly state: ButtonState,
-  ) {
-    super(type);
-  }
+export interface ButtonData {
+  button: "A" | "B";
+  state: ButtonState;
 }

--- a/packages/microbit-connection/src/device.ts
+++ b/packages/microbit-connection/src/device.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { TypedEventTarget, ValueIsEvent } from "./events.js";
+import { TypedEventTarget } from "./events.js";
 
 /**
  * Connection availability status returned by checkAvailability().
@@ -275,44 +275,24 @@ export type FlashDataSource = (
 
 export type BoardVersion = "V1" | "V2";
 
-export class ConnectionStatusEvent extends Event {
-  constructor(
-    public readonly status: ConnectionStatus,
-    public readonly previousStatus: ConnectionStatus,
-  ) {
-    super("status");
-  }
+export interface ConnectionStatusChange {
+  status: ConnectionStatus;
+  previousStatus: ConnectionStatus;
 }
 
-export class BeforeRequestDevice extends Event {
-  constructor() {
-    super("beforerequestdevice");
-  }
+export interface BackgroundErrorData {
+  message: string;
+  error?: unknown;
 }
 
-export class AfterRequestDevice extends Event {
-  constructor() {
-    super("afterrequestdevice");
-  }
+export interface DeviceConnectionEventMap {
+  status: ConnectionStatusChange;
+  backgrounderror: BackgroundErrorData;
+  beforerequestdevice: void;
+  afterrequestdevice: void;
 }
 
-export class BackgroundErrorEvent extends Event {
-  constructor(
-    public readonly errorMessage: string,
-    public readonly error?: unknown,
-  ) {
-    super("backgrounderror");
-  }
-}
-
-export class DeviceConnectionEventMap {
-  "status": ConnectionStatusEvent;
-  "backgrounderror": BackgroundErrorEvent;
-  "beforerequestdevice": Event;
-  "afterrequestdevice": Event;
-}
-
-export interface DeviceConnection<M extends ValueIsEvent<M>>
+export interface DeviceConnection<M>
   extends TypedEventTarget<DeviceConnectionEventMap & M> {
   status: ConnectionStatus;
 

--- a/packages/microbit-connection/src/device.ts
+++ b/packages/microbit-connection/src/device.ts
@@ -290,6 +290,7 @@ export interface DeviceConnectionEventMap {
   backgrounderror: BackgroundErrorData;
   beforerequestdevice: void;
   afterrequestdevice: void;
+  flash: void;
 }
 
 export interface DeviceConnection<M>

--- a/packages/microbit-connection/src/events.test.ts
+++ b/packages/microbit-connection/src/events.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { TrackingEventTarget } from "./events.js";
+import { TypedEventTarget } from "./events.js";
 
-class TestTrackingEventTarget extends TrackingEventTarget {
+interface TestEventMap {
+  foo: { value: number };
+  bar: void;
+}
+
+class TestTypedEventTarget extends TypedEventTarget<TestEventMap> {
   constructor(
     private activate: (type: string) => void,
     private deactivate: (type: string) => void,
@@ -11,6 +16,12 @@ class TestTrackingEventTarget extends TrackingEventTarget {
   public getActiveEvents(): string[] {
     return super.getActiveEvents();
   }
+  public dispatchEvent<K extends keyof TestEventMap & string>(
+    type: K,
+    ...[data]: TestEventMap[K] extends void ? [] : [data: TestEventMap[K]]
+  ): void {
+    super.dispatchEvent(type, ...([data] as any));
+  }
   protected eventActivated(type: string): void {
     this.activate(type);
   }
@@ -19,13 +30,13 @@ class TestTrackingEventTarget extends TrackingEventTarget {
   }
 }
 
-describe("TrackingEventTarget", () => {
-  const listener = () => {};
+describe("TypedEventTarget", () => {
+  const listener = (_data: { value: number }) => {};
 
   it("add remove", () => {
     const activate = vi.fn();
     const deactivate = vi.fn();
-    const target = new TestTrackingEventTarget(activate, deactivate);
+    const target = new TestTypedEventTarget(activate, deactivate);
     expect(target.getActiveEvents()).toEqual([]);
 
     target.addEventListener("foo", listener);
@@ -39,76 +50,83 @@ describe("TrackingEventTarget", () => {
     expect(target.getActiveEvents()).toEqual([]);
   });
 
-  it("callback equality", () => {
-    const listenerAlt = () => {};
+  it("identity-based dedup", () => {
+    const listenerAlt = (_data: { value: number }) => {};
 
     const activate = vi.fn();
     const deactivate = vi.fn();
-    const target = new TestTrackingEventTarget(activate, deactivate);
-    expect(target.getActiveEvents()).toEqual([]);
+    const target = new TestTypedEventTarget(activate, deactivate);
 
     target.addEventListener("foo", listenerAlt);
     target.addEventListener("foo", listener);
-    target.addEventListener("foo", listener);
+    target.addEventListener("foo", listener); // duplicate, ignored
+    expect(activate).toBeCalledTimes(1); // only called once for "foo"
+
     target.removeEventListener("foo", listener);
     expect(target.getActiveEvents()).toEqual(["foo"]);
     target.removeEventListener("foo", listenerAlt);
     expect(target.getActiveEvents()).toEqual([]);
   });
 
-  it("option equality - capture", () => {
-    const fooListener = vi.fn();
+  it("remove during dispatch", () => {
     const activate = vi.fn();
     const deactivate = vi.fn();
-    const target = new TestTrackingEventTarget(activate, deactivate);
-    expect(target.getActiveEvents()).toEqual([]);
+    const target = new TestTypedEventTarget(activate, deactivate);
+    const calls: number[] = [];
 
-    target.addEventListener("foo", fooListener, { capture: true });
-    target.addEventListener("foo", fooListener, false);
-    target.removeEventListener("foo", fooListener, true);
+    const selfRemovingListener = (_data: { value: number }) => {
+      calls.push(1);
+      target.removeEventListener("foo", selfRemovingListener);
+    };
+    const secondListener = (_data: { value: number }) => {
+      calls.push(2);
+    };
+
+    target.addEventListener("foo", selfRemovingListener);
+    target.addEventListener("foo", secondListener);
+    target.dispatchEvent("foo", { value: 42 });
+
+    // Both should have been called (Set iteration guarantees this)
+    expect(calls).toEqual([1, 2]);
+    // selfRemovingListener should be removed now
     expect(target.getActiveEvents()).toEqual(["foo"]);
-    target.dispatchEvent(new Event("foo"));
-    expect(fooListener).toBeCalledTimes(1);
   });
 
-  it("option equality", () => {
-    const fooListener = vi.fn();
-    const activate = vi.fn();
-    const deactivate = vi.fn();
-    const target = new TestTrackingEventTarget(activate, deactivate);
+  it("getActiveEvents", () => {
+    const target = new TestTypedEventTarget(vi.fn(), vi.fn());
+    const fooListener = () => {};
+    const barListener = () => {};
 
-    // Despite MDN docs claiming all options can result in another listener added
-    // it seems only capture counts for both add and remove
-    target.addEventListener("foo", fooListener, { passive: true });
-    target.addEventListener("foo", fooListener, { once: true });
-    target.addEventListener("foo", fooListener, { capture: true });
-    target.addEventListener("foo", fooListener, { capture: false });
-    target.dispatchEvent(new Event("foo"));
-    expect(fooListener).toBeCalledTimes(2);
+    target.addEventListener("foo", fooListener);
+    target.addEventListener("bar", barListener);
+    expect(target.getActiveEvents().sort()).toEqual(["bar", "foo"]);
 
-    target.removeEventListener("foo", fooListener, true);
-    expect(target.getActiveEvents()).toEqual(["foo"]);
-    target.dispatchEvent(new Event("foo"));
-    expect(fooListener).toBeCalledTimes(3);
-
-    target.removeEventListener("foo", fooListener, false);
-    expect(target.getActiveEvents()).toEqual([]);
-    target.dispatchEvent(new Event("foo"));
-    expect(fooListener).toBeCalledTimes(3);
+    target.removeEventListener("foo", fooListener);
+    expect(target.getActiveEvents()).toEqual(["bar"]);
   });
 
-  it("once", () => {
+  it("void events dispatch without argument", () => {
+    const target = new TestTypedEventTarget(vi.fn(), vi.fn());
+    const barListener = vi.fn();
+
+    target.addEventListener("bar", barListener);
+    target.dispatchEvent("bar");
+    expect(barListener).toBeCalledTimes(1);
+  });
+
+  it("dispatches correct data to listeners", () => {
+    const target = new TestTypedEventTarget(vi.fn(), vi.fn());
     const fooListener = vi.fn();
-    const activate = vi.fn();
+
+    target.addEventListener("foo", fooListener);
+    target.dispatchEvent("foo", { value: 99 });
+    expect(fooListener).toBeCalledWith({ value: 99 });
+  });
+
+  it("removing non-existent listener is a no-op", () => {
     const deactivate = vi.fn();
-    const target = new TestTrackingEventTarget(activate, deactivate);
-
-    target.addEventListener("foo", fooListener, { once: true });
-    target.dispatchEvent(new Event("foo"));
-    expect(fooListener).toBeCalledTimes(1);
-    expect(deactivate).toBeCalledTimes(1);
-
-    target.dispatchEvent(new Event("foo"));
-    expect(fooListener).toBeCalledTimes(1);
+    const target = new TestTypedEventTarget(vi.fn(), deactivate);
+    target.removeEventListener("foo", listener);
+    expect(deactivate).not.toBeCalled();
   });
 });

--- a/packages/microbit-connection/src/events.ts
+++ b/packages/microbit-connection/src/events.ts
@@ -1,220 +1,50 @@
-/**
- * Copyright (c) 2022 Jonas "DerZade" Schade
- *
- * SPDX-License-Identifier: MIT
- *
- * https://github.com/DerZade/typescript-event-target/blob/master/src/TypedEventTarget.ts
- */
+type Listener<T> = (data: T) => void;
 
-/**
- * A function that can be passed to the `listener` parameter of {@link TypedEventTarget.addEventListener} and {@link TypedEventTarget.removeEventListener}.
- *
- * @template M A map of event types to their respective event classes.
- * @template T The type of event to listen for (has to be keyof `M`).
- */
-export type TypedEventListener<M, T extends keyof M> = (
-  evt: M[T],
-) => void | Promise<void>;
+export class TypedEventTarget<M> {
+  private listeners = new Map<keyof M, Set<Listener<any>>>();
 
-/**
- * An object that can be passed to the `listener` parameter of {@link TypedEventTarget.addEventListener} and {@link TypedEventTarget.removeEventListener}.
- *
- * @template M A map of event types to their respective event classes.
- * @template T The type of event to listen for (has to be keyof `M`).
- */
-export interface TypedEventListenerObject<M, T extends keyof M> {
-  handleEvent: (evt: M[T]) => void | Promise<void>;
-}
-
-/**
- * Type of parameter `listener` in {@link TypedEventTarget.addEventListener} and {@link TypedEventTarget.removeEventListener}.
- *
- * The object that receives a notification (an object that implements the Event interface) when an event of the specified type occurs.
- *
- * Can be either an object with a handleEvent() method, or a JavaScript function.
- *
- * @template M A map of event types to their respective event classes.
- * @template T The type of event to listen for (has to be keyof `M`).
- */
-export type TypedEventListenerOrEventListenerObject<M, T extends keyof M> =
-  | TypedEventListener<M, T>
-  | TypedEventListenerObject<M, T>;
-
-export type ValueIsEvent<T> = {
-  [key in keyof T]: Event;
-};
-
-/**
- * Typescript friendly version of {@link EventTarget}
- *
- * @template M A map of event types to their respective event classes.
- *
- * @example
- * ```typescript
- * interface MyEventMap {
- *     hello: Event;
- *     time: CustomEvent<number>;
- * }
- *
- * const eventTarget = new TypedEventTarget<MyEventMap>();
- *
- * eventTarget.addEventListener('time', (event) => {
- *     // event is of type CustomEvent<number>
- * });
- * ```
- */
-export interface TypedEventTarget<M extends ValueIsEvent<M>> {
-  /** Appends an event listener for events whose type attribute value is type.
-   * The callback argument sets the callback that will be invoked when the event
-   * is dispatched.
-   *
-   * The options argument sets listener-specific options. For compatibility this
-   * can be a boolean, in which case the method behaves exactly as if the value
-   * was specified as options's capture.
-   *
-   * When set to true, options's capture prevents callback from being invoked
-   * when the event's eventPhase attribute value is BUBBLING_PHASE. When false
-   * (or not present), callback will not be invoked when event's eventPhase
-   * attribute value is CAPTURING_PHASE. Either way, callback will be invoked if
-   * event's eventPhase attribute value is AT_TARGET.
-   *
-   * When set to true, options's passive indicates that the callback will not
-   * cancel the event by invoking preventDefault(). This is used to enable
-   * performance optimizations described in § 2.8 Observing event listeners.
-   *
-   * When set to true, options's once indicates that the callback will only be
-   * invoked once after which the event listener will be removed.
-   *
-   * The event listener is appended to target's event listener list and is not
-   * appended if it has the same type, callback, and capture. */
-  addEventListener: <T extends keyof M & string>(
-    type: T,
-    listener: TypedEventListenerOrEventListenerObject<M, T> | null,
-    options?: boolean | AddEventListenerOptions,
-  ) => void;
-
-  /** Removes the event listener in target's event listener list with the same
-   * type, callback, and options. */
-  removeEventListener: <T extends keyof M & string>(
-    type: T,
-    callback: TypedEventListenerOrEventListenerObject<M, T> | null,
-    options?: EventListenerOptions | boolean,
-  ) => void;
-
-  /**
-   * Dispatches a synthetic event event to target and returns true if either
-   * event's cancelable attribute value is false or its preventDefault() method
-   * was not invoked, and false otherwise.
-   * @deprecated To ensure type safety use `dispatchTypedEvent` instead.
-   */
-  dispatchEvent: (event: Event) => boolean;
-}
-
-// We've added this in to keep track of what events are active.
-// Having done this it's questionable whether it's worth the reimplementation
-// just to use an EventTarget API.
-export class TrackingEventTarget extends EventTarget {
-  private activeEventTracking: Map<string, Registration[]> = new Map();
-
-  addEventListener(
-    type: string,
-    callback: EventListenerOrEventListenerObject | null,
-    options?: AddEventListenerOptions | boolean,
+  addEventListener<K extends keyof M & string>(
+    type: K,
+    listener: Listener<M[K]>,
   ): void {
-    if (callback !== null) {
-      const registrations = this.activeEventTracking.get(type) ?? [];
-      const wasEmpty = registrations.length === 0;
-      const registration = new Registration(callback, options ?? false);
-      if (!registrations.find((r) => r.eq(registration))) {
-        registrations.push(registration);
-        this.activeEventTracking.set(type, registrations);
-        if (wasEmpty) {
-          this.eventActivated(type);
-        }
+    let set = this.listeners.get(type);
+    const wasEmpty = !set || set.size === 0;
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    if (!set.has(listener)) {
+      set.add(listener);
+      if (wasEmpty) this.eventActivated(type);
+    }
+  }
+
+  removeEventListener<K extends keyof M & string>(
+    type: K,
+    listener: Listener<M[K]>,
+  ): void {
+    const set = this.listeners.get(type);
+    if (set?.delete(listener) && set.size === 0) {
+      this.listeners.delete(type);
+      this.eventDeactivated(type);
+    }
+  }
+
+  protected dispatchEvent<K extends keyof M & string>(
+    type: K,
+    ...[data]: M[K] extends void ? [] : [data: M[K]]
+  ): void {
+    const set = this.listeners.get(type);
+    if (set) {
+      for (const listener of set) {
+        listener(data as M[K]);
       }
     }
-    super.addEventListener(type, callback, options);
   }
 
-  removeEventListener(
-    type: string,
-    callback: EventListenerOrEventListenerObject | null,
-    options?: EventListenerOptions | boolean,
-  ): void {
-    if (callback !== null) {
-      const registration = new Registration(callback, options ?? false);
-      this.filterRegistrations(type, (r) => !r.eq(registration));
-    }
-    super.removeEventListener(type, callback, options);
-  }
-
-  dispatchEvent(event: Event): boolean {
-    const result = super.dispatchEvent(event);
-    this.filterRegistrations(event.type, (r) => !r.isOnce());
-    return result;
-  }
-
-  private filterRegistrations(
-    type: string,
-    predicate: (r: Registration) => boolean,
-  ): void {
-    let registrations = this.activeEventTracking.get(type) ?? [];
-    registrations = registrations.filter(predicate);
-    if (registrations.length === 0) {
-      this.activeEventTracking.delete(type);
-      this.eventDeactivated(type);
-    } else {
-      this.activeEventTracking.set(type, registrations);
-    }
-  }
-
-  protected eventActivated(type: string) {}
-
-  protected eventDeactivated(type: string) {}
-
+  protected eventActivated(_type: string): void {}
+  protected eventDeactivated(_type: string): void {}
   protected getActiveEvents(): string[] {
-    return [...this.activeEventTracking.keys()];
+    return [...this.listeners.keys()] as string[];
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class TypedEventTarget<
-  M extends ValueIsEvent<M>,
-> extends TrackingEventTarget {
-  /**
-   * Dispatches a synthetic event event to target and returns true if either
-   * event's cancelable attribute value is false or its preventDefault() method
-   * was not invoked, and false otherwise.
-   */
-  public dispatchTypedEvent<T extends keyof M>(_type: T, event: M[T]): boolean {
-    return super.dispatchEvent(event);
-  }
-}
-
-class Registration {
-  constructor(
-    private callback: EventListenerOrEventListenerObject,
-    private options: AddEventListenerOptions | boolean,
-  ) {}
-
-  isOnce() {
-    return typeof this.options === "object" && this.options.once === true;
-  }
-
-  eq(other: Registration) {
-    return (
-      other.callback === this.callback &&
-      eqUseCapture(this.options, other.options)
-    );
-  }
-}
-
-const eqUseCapture = (
-  left: AddEventListenerOptions | boolean,
-  right: AddEventListenerOptions | boolean,
-) => {
-  const leftValue = typeof left === "boolean" ? left : left.capture ?? false;
-  const rightValue =
-    typeof right === "boolean" ? right : right.capture ?? false;
-  return leftValue === rightValue;
-};

--- a/packages/microbit-connection/src/index.ts
+++ b/packages/microbit-connection/src/index.ts
@@ -1,19 +1,17 @@
 /**
  * @module @microbit/microbit-connection
  */
-import { AccelerometerData, AccelerometerDataEvent } from "./accelerometer.js";
+import { AccelerometerData } from "./accelerometer.js";
 import { BoardId } from "./board-id.js";
-import { ButtonEvent, ButtonEventType, ButtonState } from "./buttons.js";
+import { ButtonData, ButtonEventType, ButtonState } from "./buttons.js";
 import { DeviceBondState } from "./device-bond-state.js";
 import {
-  AfterRequestDevice,
-  BackgroundErrorEvent,
-  BeforeRequestDevice,
+  BackgroundErrorData,
   BoardVersion,
   ConnectOptions,
   ConnectionAvailabilityStatus,
   ConnectionStatus,
-  ConnectionStatusEvent,
+  ConnectionStatusChange,
   DeviceConnection,
   DeviceConnectionEventMap,
   DeviceError,
@@ -28,50 +26,37 @@ import {
 import { TypedEventTarget } from "./events.js";
 import { LedMatrix } from "./led.js";
 import { Logging, LoggingEvent } from "./logging.js";
-import { MagnetometerData, MagnetometerDataEvent } from "./magnetometer.js";
+import { MagnetometerData } from "./magnetometer.js";
 import {
-  FlashEvent,
   SerialConnectionEventMap,
-  SerialDataEvent,
-  SerialErrorEvent,
-  SerialResetEvent,
+  SerialData,
+  SerialErrorData,
 } from "./serial-events.js";
-import { ServiceConnectionEventMap } from "./service-events.js";
-import { UARTDataEvent } from "./uart.js";
+import { ServiceConnectionEventMap, UartData } from "./service-events.js";
 
 export {
-  AfterRequestDevice,
-  BackgroundErrorEvent,
-  BeforeRequestDevice,
   BoardId,
   ConnectionStatus,
-  ConnectionStatusEvent,
-  DeviceConnectionEventMap,
   DeviceError,
   FlashDataError,
   assertConnected,
-  FlashEvent,
   ProgressStage,
-  SerialConnectionEventMap,
-  SerialDataEvent,
-  SerialErrorEvent,
-  SerialResetEvent,
-  ServiceConnectionEventMap,
   TypedEventTarget,
-  UARTDataEvent,
 };
 
 export type {
   AccelerometerData,
-  AccelerometerDataEvent,
+  BackgroundErrorData,
   BoardVersion,
-  ConnectionAvailabilityStatus,
-  ButtonEvent,
+  ButtonData,
   ButtonEventType,
   ButtonState,
   ConnectOptions,
+  ConnectionAvailabilityStatus,
+  ConnectionStatusChange,
   DeviceBondState,
   DeviceConnection,
+  DeviceConnectionEventMap,
   DeviceErrorCode,
   FlashDataSource,
   FlashOptions,
@@ -79,6 +64,10 @@ export type {
   Logging,
   LoggingEvent,
   MagnetometerData,
-  MagnetometerDataEvent,
   ProgressCallback,
+  SerialConnectionEventMap,
+  SerialData,
+  SerialErrorData,
+  ServiceConnectionEventMap,
+  UartData,
 };

--- a/packages/microbit-connection/src/magnetometer-service.ts
+++ b/packages/microbit-connection/src/magnetometer-service.ts
@@ -1,12 +1,11 @@
 import { BleClient } from "@capacitor-community/bluetooth-le";
 import { Service } from "./bluetooth-device-wrapper.js";
 import { profile } from "./bluetooth-profile.js";
-import { MagnetometerData, MagnetometerDataEvent } from "./magnetometer.js";
+import { MagnetometerData } from "./magnetometer.js";
 import {
   TypedServiceEvent,
   TypedServiceEventDispatcher,
 } from "./service-events.js";
-import { BackgroundErrorEvent } from "./device.js";
 
 export class MagnetometerService implements Service {
   uuid = profile.magnetometer.id;
@@ -94,17 +93,14 @@ export class MagnetometerService implements Service {
           profile.magnetometer.characteristics.data.id,
           (value: DataView) => {
             const data = this.dataViewToData(value);
-            this.dispatchTypedEvent(
-              "magnetometerdatachanged",
-              new MagnetometerDataEvent(data),
-            );
+            this.dispatchTypedEvent("magnetometerdatachanged", data);
           },
         );
       } catch (e) {
-        this.dispatchTypedEvent(
-          "backgrounderror",
-          new BackgroundErrorEvent("Failed to start notifications", e),
-        );
+        this.dispatchTypedEvent("backgrounderror", {
+          message: "Failed to start notifications",
+          error: e,
+        });
       }
     }
   }
@@ -118,10 +114,10 @@ export class MagnetometerService implements Service {
           profile.magnetometer.characteristics.data.id,
         );
       } catch (e) {
-        this.dispatchTypedEvent(
-          "backgrounderror",
-          new BackgroundErrorEvent("Failed to stop notifications", e),
-        );
+        this.dispatchTypedEvent("backgrounderror", {
+          message: "Failed to stop notifications",
+          error: e,
+        });
       }
     }
   }

--- a/packages/microbit-connection/src/magnetometer.ts
+++ b/packages/microbit-connection/src/magnetometer.ts
@@ -3,9 +3,3 @@ export interface MagnetometerData {
   y: number;
   z: number;
 }
-
-export class MagnetometerDataEvent extends Event {
-  constructor(public readonly data: MagnetometerData) {
-    super("magnetometerdatachanged");
-  }
-}

--- a/packages/microbit-connection/src/serial-events.ts
+++ b/packages/microbit-connection/src/serial-events.ts
@@ -10,5 +10,4 @@ export interface SerialConnectionEventMap {
   serialdata: SerialData;
   serialreset: void;
   serialerror: SerialErrorData;
-  flash: void;
 }

--- a/packages/microbit-connection/src/serial-events.ts
+++ b/packages/microbit-connection/src/serial-events.ts
@@ -1,30 +1,14 @@
-export class SerialDataEvent extends Event {
-  constructor(public readonly data: string) {
-    super("serialdata");
-  }
+export interface SerialData {
+  data: string;
 }
 
-export class SerialResetEvent extends Event {
-  constructor() {
-    super("serialreset");
-  }
+export interface SerialErrorData {
+  error: unknown;
 }
 
-export class SerialErrorEvent extends Event {
-  constructor(public readonly error: unknown) {
-    super("serialerror");
-  }
-}
-
-export class FlashEvent extends Event {
-  constructor() {
-    super("flash");
-  }
-}
-
-export class SerialConnectionEventMap {
-  "serialdata": SerialDataEvent;
-  "serialreset": SerialResetEvent;
-  "serialerror": SerialErrorEvent;
-  "flash": FlashEvent;
+export interface SerialConnectionEventMap {
+  serialdata: SerialData;
+  serialreset: void;
+  serialerror: SerialErrorData;
+  flash: void;
 }

--- a/packages/microbit-connection/src/service-events.ts
+++ b/packages/microbit-connection/src/service-events.ts
@@ -1,26 +1,27 @@
-import { AccelerometerDataEvent } from "./accelerometer.js";
-import { ButtonEvent } from "./buttons.js";
+import { AccelerometerData } from "./accelerometer.js";
+import { ButtonData } from "./buttons.js";
 import { DeviceConnectionEventMap } from "./device.js";
-import { MagnetometerDataEvent } from "./magnetometer.js";
-import { UARTDataEvent } from "./uart.js";
+import { MagnetometerData } from "./magnetometer.js";
 
-export class ServiceConnectionEventMap {
-  "accelerometerdatachanged": AccelerometerDataEvent;
-  "buttonachanged": ButtonEvent;
-  "buttonbchanged": ButtonEvent;
-  "magnetometerdatachanged": MagnetometerDataEvent;
-  "uartdata": UARTDataEvent;
+export interface UartData {
+  value: Uint8Array;
+}
+
+export interface ServiceConnectionEventMap {
+  accelerometerdatachanged: AccelerometerData;
+  buttonachanged: ButtonData;
+  buttonbchanged: ButtonData;
+  magnetometerdatachanged: MagnetometerData;
+  uartdata: UartData;
 }
 
 export type CharacteristicDataTarget = EventTarget & {
   value: DataView;
 };
 
-export type TypedServiceEvent = keyof (ServiceConnectionEventMap &
-  DeviceConnectionEventMap);
-
-export type TypedServiceEventDispatcher = (
-  _type: TypedServiceEvent,
-  event: (ServiceConnectionEventMap &
-    DeviceConnectionEventMap)[TypedServiceEvent],
-) => boolean;
+type AllEventMap = ServiceConnectionEventMap & DeviceConnectionEventMap;
+export type TypedServiceEvent = keyof AllEventMap;
+export type TypedServiceEventDispatcher = <K extends TypedServiceEvent>(
+  type: K,
+  ...[data]: AllEventMap[K] extends void ? [] : [data: AllEventMap[K]]
+) => void;

--- a/packages/microbit-connection/src/uart-service.ts
+++ b/packages/microbit-connection/src/uart-service.ts
@@ -5,8 +5,6 @@ import {
   TypedServiceEvent,
   TypedServiceEventDispatcher,
 } from "./service-events.js";
-import { UARTDataEvent } from "./uart.js";
-import { BackgroundErrorEvent } from "./device.js";
 
 export class UARTService implements Service {
   uuid = profile.uart.id;
@@ -28,17 +26,16 @@ export class UARTService implements Service {
           profile.uart.id,
           profile.uart.characteristics.tx.id,
           (value: DataView) => {
-            this.dispatchTypedEvent(
-              "uartdata",
-              new UARTDataEvent(new Uint8Array(value.buffer)),
-            );
+            this.dispatchTypedEvent("uartdata", {
+              value: new Uint8Array(value.buffer),
+            });
           },
         );
       } catch (e) {
-        this.dispatchTypedEvent(
-          "backgrounderror",
-          new BackgroundErrorEvent("Failed to start notifications", e),
-        );
+        this.dispatchTypedEvent("backgrounderror", {
+          message: "Failed to start notifications",
+          error: e,
+        });
       }
     }
   }

--- a/packages/microbit-connection/src/uart.ts
+++ b/packages/microbit-connection/src/uart.ts
@@ -1,5 +1,0 @@
-export class UARTDataEvent extends Event {
-  constructor(public readonly value: Uint8Array) {
-    super("uartdata");
-  }
-}

--- a/packages/microbit-connection/src/usb-radio-bridge.ts
+++ b/packages/microbit-connection/src/usb-radio-bridge.ts
@@ -4,23 +4,22 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { AccelerometerDataEvent } from "./accelerometer.js";
-import { ButtonEvent, ButtonState } from "./buttons.js";
+import { ButtonState } from "./buttons.js";
 import {
   BoardVersion,
   ConnectionAvailabilityStatus,
   ConnectionStatus,
-  ConnectionStatusEvent,
+  ConnectionStatusChange,
   DeviceConnection,
   DeviceConnectionEventMap,
 } from "./device.js";
 import { TypedEventTarget } from "./events.js";
 import { Logging, ConsoleLogging } from "./logging.js";
-import { SerialDataEvent, SerialErrorEvent } from "./serial-events.js";
 import {
   ServiceConnectionEventMap,
   TypedServiceEventDispatcher,
 } from "./service-events.js";
+import { SerialData, SerialErrorData } from "./serial-events.js";
 import * as protocol from "./usb-serial-protocol.js";
 import { MicrobitUSBConnection } from "./usb.js";
 
@@ -75,7 +74,7 @@ class MicrobitRadioBridgeConnectionImpl
   private disconnectPromise: Promise<void> | undefined;
   private serialSessionOpen = false;
 
-  private delegateStatusListener = (e: ConnectionStatusEvent) => {
+  private delegateStatusListener = (e: ConnectionStatusChange) => {
     const currentStatus = this.status;
     if (e.status !== ConnectionStatus.CONNECTED) {
       this.setStatus(e.status);
@@ -163,7 +162,7 @@ class MicrobitRadioBridgeConnectionImpl
         this.logging,
         this.remoteDeviceId,
         this.delegate,
-        this.dispatchTypedEvent.bind(this),
+        this.dispatchEvent.bind(this),
         {
           onConnecting: () => {
             this.setStatus(ConnectionStatus.CONNECTING);
@@ -222,10 +221,10 @@ class MicrobitRadioBridgeConnectionImpl
     const previousStatus = this.status;
     this.status = newStatus;
     this.log("Radio connection status " + newStatus);
-    this.dispatchTypedEvent(
-      "status",
-      new ConnectionStatusEvent(newStatus, previousStatus),
-    );
+    this.dispatchEvent("status", {
+      status: newStatus,
+      previousStatus,
+    });
   }
 
   private statusFromDelegate(): ConnectionStatus {
@@ -245,12 +244,12 @@ class RadioBridgeSerialSession {
   private lastReceivedMessageTimestamp: number | undefined;
   private connectionCheckIntervalId: ReturnType<typeof setInterval> | undefined;
 
-  private serialErrorListener = (event: SerialErrorEvent) => {
+  private serialErrorListener = (event: SerialErrorData) => {
     this.logging.error("Serial error", event.error);
     void this.dispose();
   };
 
-  private serialDataListener = (event: SerialDataEvent) => {
+  private serialDataListener = (event: SerialData) => {
     const { data } = event;
     const messages = protocol.splitMessages(this.unprocessedData + data);
     this.unprocessedData = messages.remainingInput;
@@ -263,14 +262,11 @@ class RadioBridgeSerialSession {
       if (sensorData) {
         this.onPeriodicMessageReceived?.();
 
-        this.dispatchTypedEvent(
-          "accelerometerdatachanged",
-          new AccelerometerDataEvent({
-            x: sensorData.accelerometerX,
-            y: sensorData.accelerometerY,
-            z: sensorData.accelerometerZ,
-          }),
-        );
+        this.dispatchTypedEvent("accelerometerdatachanged", {
+          x: sensorData.accelerometerX,
+          y: sensorData.accelerometerY,
+          z: sensorData.accelerometerZ,
+        });
         this.processButton("buttonA", "buttonachanged", sensorData);
         this.processButton("buttonB", "buttonbchanged", sensorData);
       } else {
@@ -294,13 +290,12 @@ class RadioBridgeSerialSession {
   ) {
     if (sensorData[button] !== this.previousButtonState[button]) {
       this.previousButtonState[button] = sensorData[button];
-      this.dispatchTypedEvent(
-        type,
-        new ButtonEvent(
-          type,
-          sensorData[button] ? ButtonState.ShortPress : ButtonState.NotPressed,
-        ),
-      );
+      this.dispatchTypedEvent(type, {
+        button: type === "buttonachanged" ? "A" : "B",
+        state: sensorData[button]
+          ? ButtonState.ShortPress
+          : ButtonState.NotPressed,
+      });
     }
   }
 

--- a/packages/microbit-connection/src/usb.test.ts
+++ b/packages/microbit-connection/src/usb.test.ts
@@ -9,7 +9,7 @@
  * It might be we could create a custom environment that was web but
  * with a tweak to Buffer.
  */
-import { ConnectionStatus, ConnectionStatusEvent } from "./device.js";
+import { ConnectionStatus, ConnectionStatusChange } from "./device.js";
 import { applyDeviceFilters, createUSBConnection } from "./usb.js";
 import { beforeAll, beforeEach, expect, vi, describe, it } from "vitest";
 
@@ -77,7 +77,7 @@ describeDeviceOnly("MicrobitUSBConnection (WebUSB supported)", () => {
   it("connects and disconnects updating status and events", async () => {
     const events: ConnectionStatus[] = [];
     const connection = createUSBConnection();
-    connection.addEventListener("status", (event: ConnectionStatusEvent) => {
+    connection.addEventListener("status", (event: ConnectionStatusChange) => {
       events.push(event.status);
     });
 
@@ -191,7 +191,7 @@ describe("Tab visibility and PAUSED state", () => {
         resolve();
         return;
       }
-      const listener = (event: ConnectionStatusEvent) => {
+      const listener = (event: ConnectionStatusChange) => {
         if (event.status === status) {
           connection.removeEventListener("status", listener);
           resolve();

--- a/packages/microbit-connection/src/usb.ts
+++ b/packages/microbit-connection/src/usb.ts
@@ -6,13 +6,10 @@
 import { TimeoutError, withTimeout } from "./async-util.js";
 import { throwIfUnavailable } from "./availability.js";
 import {
-  AfterRequestDevice,
-  BeforeRequestDevice,
   BoardVersion,
   ConnectOptions,
   ConnectionAvailabilityStatus,
   ConnectionStatus,
-  ConnectionStatusEvent,
   DeviceConnection,
   DeviceConnectionEventMap,
   DeviceError,
@@ -26,13 +23,7 @@ import {
 import { TypedEventTarget } from "./events.js";
 import { Logging, ConsoleLogging } from "./logging.js";
 import { PromiseQueue } from "./promise-queue.js";
-import {
-  FlashEvent,
-  SerialConnectionEventMap,
-  SerialDataEvent,
-  SerialErrorEvent,
-  SerialResetEvent,
-} from "./serial-events.js";
+import { SerialConnectionEventMap } from "./serial-events.js";
 import { DAPWrapper } from "./usb-device-wrapper.js";
 import { PartialFlashing } from "./usb-partial-flashing.js";
 
@@ -163,7 +154,7 @@ class MicrobitUSBConnectionImpl
   private serialStateChangeQueue = new PromiseQueue();
 
   private serialListener = (data: string) => {
-    this.dispatchTypedEvent("serialdata", new SerialDataEvent(data));
+    this.dispatchEvent("serialdata", { data });
   };
 
   private flashing: boolean = false;
@@ -309,7 +300,7 @@ class MicrobitUSBConnectionImpl
       await this.withEnrichedErrors(() =>
         this.flashInternal(dataSource, options),
       );
-      this.dispatchTypedEvent("flash", new FlashEvent());
+      this.dispatchEvent("flash");
 
       const flashTime = new Date().getTime() - startTime;
       this.logging.event({
@@ -396,7 +387,7 @@ class MicrobitUSBConnectionImpl
           this.log("Finished listening for serial data");
         })
         .catch((e) => {
-          this.dispatchTypedEvent("serialerror", new SerialErrorEvent(e));
+          this.dispatchEvent("serialerror", { error: e });
         })
         .finally(() => {
           this.serialState = false;
@@ -410,7 +401,7 @@ class MicrobitUSBConnectionImpl
         return;
       }
       this.connection.stopSerial(this.serialListener);
-      this.dispatchTypedEvent("serialreset", new SerialResetEvent());
+      this.dispatchEvent("serialreset");
     });
   }
 
@@ -448,10 +439,10 @@ class MicrobitUSBConnectionImpl
     const previousStatus = this.status;
     this.status = newStatus;
     this.log("USB connection status " + newStatus);
-    this.dispatchTypedEvent(
-      "status",
-      new ConnectionStatusEvent(newStatus, previousStatus),
-    );
+    this.dispatchEvent("status", {
+      status: newStatus,
+      previousStatus,
+    });
   }
 
   private async withEnrichedErrors<T>(f: () => Promise<T>): Promise<T> {
@@ -616,14 +607,14 @@ class MicrobitUSBConnectionImpl
   }
 
   private async chooseDevice(): Promise<USBDevice> {
-    this.dispatchTypedEvent("beforerequestdevice", new BeforeRequestDevice());
+    this.dispatchEvent("beforerequestdevice");
     try {
       this.device = await navigator.usb.requestDevice({
         exclusionFilters: this.exclusionFilters,
         filters: defaultFilters,
       });
     } finally {
-      this.dispatchTypedEvent("afterrequestdevice", new AfterRequestDevice());
+      this.dispatchEvent("afterrequestdevice");
     }
     return this.device;
   }


### PR DESCRIPTION
Drop EventTarget inheritance and ~220 lines of type gymnastics (Registration, ValueIsEvent, TrackingEventTarget) in favour of a simple Map<key, Set<Listener>> implementation. Listeners now receive plain data payloads directly instead of Event wrapper objects.

Aligning with EventTarget has been nothing but pain especially for users who mock/stub the connections which is common in our consuming apps for tests.

Removed: ConnectionStatusEvent, BeforeRequestDevice, AfterRequestDevice, BackgroundErrorEvent, SerialDataEvent, SerialErrorEvent, SerialResetEvent, FlashEvent, AccelerometerDataEvent, ButtonEvent, MagnetometerDataEvent, UARTDataEvent classes. Added ButtonData interface.