### PR TITLE
Breaking: Move serialWrite from DeviceConnection to USB only

### DIFF
--- a/packages/microbit-connection/src/bluetooth.ts
+++ b/packages/microbit-connection/src/bluetooth.ts
@@ -378,12 +378,6 @@ class MicrobitBluetoothConnectionImpl
     }
   }
 
-  serialWrite(data: string): Promise<void> {
-    assertConnected(this.connection);
-    // TODO
-    return Promise.resolve();
-  }
-
   async clearDevice(): Promise<void> {
     await this.disconnect();
     this.device = undefined;

--- a/packages/microbit-connection/src/device.ts
+++ b/packages/microbit-connection/src/device.ts
@@ -342,15 +342,6 @@ export interface DeviceConnection<M>
   disconnect(): Promise<void>;
 
   /**
-   * Write serial data to the device.
-   *
-   * @param data The data to write.
-   * @returns A promise that resolves when the write is complete.
-   * @throws {DeviceError} with code `not-connected` if there is no connection.
-   */
-  serialWrite(data: string): Promise<void>;
-
-  /**
    * Flash the micro:bit.
    *
    * Not all connection types support flashing. For example, radio bridge

--- a/packages/microbit-connection/src/usb.ts
+++ b/packages/microbit-connection/src/usb.ts
@@ -80,6 +80,15 @@ export interface MicrobitUSBConnectionOptions {
 export interface MicrobitUSBConnection
   extends DeviceConnection<SerialConnectionEventMap> {
   /**
+   * Write serial data to the device.
+   *
+   * @param data The data to write.
+   * @returns A promise that resolves when the write is complete.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
+   */
+  serialWrite(data: string): Promise<void>;
+
+  /**
    * Gets micro:bit deviceId.
    *
    * Cached after the first successful connection until {@link clearDevice}


### PR DESCRIPTION
Serial is a USB-specific concern — Bluetooth has UART (different data model) and the Bluetooth implementation was just a stub. Remove serialWrite from the base DeviceConnection interface and add it to MicrobitUSBConnection instead. The radio bridge intentionally does not expose serialWrite as it would conflict with the serial protocol used to relay radio messages.

Note this targets document-post-connection for now but will eventually be apps once those are reviewed.