### PR TITLE
Fix UICR not updated during WebUSB partial flashing

### DIFF
--- a/apps/hardware-test/src/main.ts
+++ b/apps/hardware-test/src/main.ts
@@ -131,7 +131,7 @@ function createUSBSuite({
         },
       },
       {
-        name: "Full flash fallback to partial",
+        name: "Full flash fallback to partial, UICR recovery",
         run: async (ctx) => {
           assertConnected(ctx);
           ctx.log("Flashing Python with fault injection during full...");
@@ -142,25 +142,21 @@ function createUSBSuite({
               stages.includes("PartialFlashing"),
             `Full failed then fell back to partial (stages: ${stages.join(" → ")})`,
           );
-        },
-      },
-      {
-        name: "UICR recovery after interrupted full flash",
-        run: async (ctx) => {
-          // The previous test ("Full flash fallback to partial") left the
-          // device with correct main flash but erased UICR: the full flash
-          // FLASH_OPEN triggered a chip erase (wiping UICR), the fault
-          // interrupted before UICR records were written, and the fallback
-          // partial flash completed main flash but skipped UICR
-          // (targetAddr >= 0x10000000).
-          //
-          // Re-flashing the same hex should detect the UICR mismatch and
-          // repair it so the program actually boots.
-          assertConnected(ctx);
-          ctx.log("Re-flashing Python, expecting UICR recovery...");
-          const hex = await ctx.fetchHex("incremental-python.hex");
-          const stages = await flashWithProgress(ctx, hex);
-          assertFlashType(ctx, stages, "PartialFlashing");
+          // The fault interrupted after FLASH_OPEN triggered a chip erase
+          // (wiping UICR). The fallback partial flash wrote main flash but
+          // partial flashing skips addresses >= 0x10000000. ensureUicr()
+          // should have detected the blank UICR and repaired it.
+          ctx.assert(
+            ctx.libraryLogs.some((m) => m.includes("UICR mismatch")),
+            "Library detected UICR mismatch",
+          );
+          ctx.assert(
+            ctx.libraryLogs.some((m) => m.includes("UICR repair complete")),
+            "Library repaired UICR",
+          );
+          ctx.log("Flashing incremental Python to verify device boots...");
+          const verifyHex = await ctx.fetchHex("incremental-python.hex");
+          await flashWithProgress(ctx, verifyHex);
           ctx.log("Checking device boots after UICR recovery...");
           await assertSerialFromZero(ctx, 5, 15_000);
         },

--- a/apps/hardware-test/src/main.ts
+++ b/apps/hardware-test/src/main.ts
@@ -145,6 +145,27 @@ function createUSBSuite({
         },
       },
       {
+        name: "UICR recovery after interrupted full flash",
+        run: async (ctx) => {
+          // The previous test ("Full flash fallback to partial") left the
+          // device with correct main flash but erased UICR: the full flash
+          // FLASH_OPEN triggered a chip erase (wiping UICR), the fault
+          // interrupted before UICR records were written, and the fallback
+          // partial flash completed main flash but skipped UICR
+          // (targetAddr >= 0x10000000).
+          //
+          // Re-flashing the same hex should detect the UICR mismatch and
+          // repair it so the program actually boots.
+          assertConnected(ctx);
+          ctx.log("Re-flashing Python, expecting UICR recovery...");
+          const hex = await ctx.fetchHex("incremental-python.hex");
+          const stages = await flashWithProgress(ctx, hex);
+          assertFlashType(ctx, stages, "PartialFlashing");
+          ctx.log("Checking device boots after UICR recovery...");
+          await assertSerialFromZero(ctx, 5, 15_000);
+        },
+      },
+      {
         name: "Clean disconnect",
         run: async (ctx) => {
           await ctx.connection.disconnect();

--- a/apps/hardware-test/src/main.ts
+++ b/apps/hardware-test/src/main.ts
@@ -146,12 +146,9 @@ function createUSBSuite({
           // (wiping UICR). The fallback partial flash wrote main flash but
           // partial flashing skips addresses >= 0x10000000. ensureUicr()
           // should have detected the blank UICR and repaired it.
-          ctx.assert(
-            ctx.libraryLogs.some((m) => m.includes("UICR mismatch")),
-            "Library detected UICR mismatch",
-          );
-          ctx.assert(
-            ctx.libraryLogs.some((m) => m.includes("UICR repair complete")),
+          ctx.assertLogged("UICR mismatch", "Library detected UICR mismatch");
+          ctx.assertLogged(
+            "UICR repair complete",
             "Library repaired UICR",
           );
           ctx.log("Flashing incremental Python to verify device boots...");

--- a/apps/hardware-test/src/runner.ts
+++ b/apps/hardware-test/src/runner.ts
@@ -6,6 +6,8 @@
 import {
   ConnectionStatus,
   type ConnectionStatusChange,
+  type Logging,
+  type LoggingEvent,
 } from "@microbit/microbit-connection";
 import {
   createUSBConnection,
@@ -86,6 +88,8 @@ export class SerialAccumulator {
 export interface TestContext {
   connection: MicrobitUSBConnection;
   serial: SerialAccumulator;
+  /** Messages logged by the library (via Logging.log) during the current test. */
+  libraryLogs: string[];
   log: (msg: string) => void;
   assert: (condition: boolean, msg: string) => void;
   waitForUser: (instruction: string) => Promise<void>;
@@ -121,17 +125,38 @@ interface TestState {
   };
 }
 
+class CapturingLogging implements Logging {
+  messages: string[] = [];
+  event(event: LoggingEvent): void {
+    console.log(event);
+  }
+  error(message: string, e: unknown): void {
+    console.error(message, e);
+  }
+  log(e: any): void {
+    const msg = String(e);
+    this.messages.push(msg);
+    console.log(e);
+  }
+  clear(): void {
+    this.messages.length = 0;
+  }
+}
+
 export class TestRunner {
   private connection: MicrobitUSBConnection;
   private serial: SerialAccumulator;
+  private logging: CapturingLogging;
   private container: HTMLElement;
   private tests: TestState[] = [];
   private running = false;
 
   constructor(container: HTMLElement) {
     this.container = container;
+    this.logging = new CapturingLogging();
     this.connection = createUSBConnection({
       deviceSelectionMode: DeviceSelectionMode.UseAnyAllowed,
+      logging: this.logging,
     });
     this.serial = new SerialAccumulator();
   }
@@ -258,9 +283,11 @@ export class TestRunner {
     this.setStatus(test, "running");
     test.el.root.classList.add("expanded");
 
+    this.logging.clear();
     const ctx: TestContext = {
       connection: this.connection,
       serial: this.serial,
+      libraryLogs: this.logging.messages,
       log: (msg: string) => this.appendLog(test, msg, "info"),
       assert: (condition: boolean, msg: string) => {
         if (!condition) {

--- a/apps/hardware-test/src/runner.ts
+++ b/apps/hardware-test/src/runner.ts
@@ -88,10 +88,9 @@ export class SerialAccumulator {
 export interface TestContext {
   connection: MicrobitUSBConnection;
   serial: SerialAccumulator;
-  /** Messages logged by the library (via Logging.log) during the current test. */
-  libraryLogs: string[];
   log: (msg: string) => void;
   assert: (condition: boolean, msg: string) => void;
+  assertLogged: (pattern: string, msg: string) => void;
   waitForUser: (instruction: string) => Promise<void>;
   waitForStatus: (
     status: ConnectionStatus,
@@ -287,10 +286,17 @@ export class TestRunner {
     const ctx: TestContext = {
       connection: this.connection,
       serial: this.serial,
-      libraryLogs: this.logging.messages,
       log: (msg: string) => this.appendLog(test, msg, "info"),
       assert: (condition: boolean, msg: string) => {
         if (!condition) {
+          this.appendLog(test, `FAIL: ${msg}`, "error");
+          throw new Error(`Assertion failed: ${msg}`);
+        }
+        this.appendLog(test, `PASS: ${msg}`, "success");
+      },
+      assertLogged: (pattern: string, msg: string) => {
+        const found = this.logging.messages.some((m) => m.includes(pattern));
+        if (!found) {
           this.appendLog(test, `FAIL: ${msg}`, "error");
           throw new Error(`Assertion failed: ${msg}`);
         }

--- a/packages/microbit-connection/src/usb/arm-debug.ts
+++ b/packages/microbit-connection/src/usb/arm-debug.ts
@@ -123,6 +123,7 @@ const WAIT_DELAY = 100;
 export async function waitFor(
   fn: () => Promise<boolean>,
   timeout = 10_000,
+  delay = WAIT_DELAY,
 ): Promise<void> {
   const deadline = timeout > 0 ? Date.now() + timeout : 0;
   while (true) {
@@ -133,7 +134,7 @@ export async function waitFor(
         message: "Wait timed out",
       });
     }
-    await new Promise((resolve) => setTimeout(resolve, WAIT_DELAY));
+    await new Promise((resolve) => setTimeout(resolve, delay));
   }
 }
 

--- a/packages/microbit-connection/src/usb/partial-flashing.ts
+++ b/packages/microbit-connection/src/usb/partial-flashing.ts
@@ -98,6 +98,7 @@ const stackAddr = 0x20001000;
 // cleared (1→0); restoring a bit to 1 requires erasing the entire UICR region.
 // https://docs.nordicsemi.com/bundle/ps_nrf52833/page/uicr.html
 const UICR_BASE = 0x10001000;
+const UICR_LIMIT = 0x10002000;
 
 // nRF52 NVMC registers for UICR erase/write
 const NVMC_CONFIG = 0x4001e504;
@@ -353,7 +354,7 @@ export class PartialFlashing {
 
     const uicrEntries: UicrEntry[] = [];
     for (const [addr, block] of memoryMap) {
-      if (addr < UICR_BASE) continue;
+      if (addr < UICR_BASE || addr >= UICR_LIMIT) continue;
       for (let i = 0; i < block.length; i += 4) {
         uicrEntries.push({
           address: addr + i,
@@ -416,6 +417,8 @@ export class PartialFlashing {
     const waitNvmcReady = () =>
       waitFor(
         async () => ((await this.device.adi.readMem32(NVMC_READY)) & 1) === 1,
+        10_000,
+        5,
       );
 
     if (needsErase) {

--- a/packages/microbit-connection/src/usb/partial-flashing.ts
+++ b/packages/microbit-connection/src/usb/partial-flashing.ts
@@ -92,6 +92,26 @@ const loadAddr = membase;
 const dataAddr = 0x20002000;
 const stackAddr = 0x20001000;
 
+// UICR (User Information Configuration Registers) — non-volatile registers
+// for chip config (bootloader address, NFC pin mode, etc). Bits can only be
+// cleared (1→0); restoring a bit to 1 requires erasing the entire UICR region.
+// https://docs.nordicsemi.com/bundle/ps_nrf52833/page/uicr.html
+const UICR_BASE = 0x10001000;
+
+// nRF52 NVMC registers for UICR erase/write
+const NVMC_CONFIG = 0x4001e504;
+const NVMC_ERASEUICR = 0x4001e514;
+const NVMC_READY = 0x4001e400;
+const NVMC_CONFIG_WEN = 1; // Write enable
+const NVMC_CONFIG_EEN = 2; // Erase enable
+const NVMC_CONFIG_REN = 0; // Read only
+
+/** A UICR word: address and expected 32-bit value. */
+interface UicrEntry {
+  address: number;
+  value: number;
+}
+
 /**
  * Uses a USBDeviceWrapper to flash the micro:bit.
  *
@@ -151,7 +171,7 @@ export class PartialFlashing {
     nextPage: Page,
     i: number,
   ): Promise<void> {
-    // TODO: This short-circuits UICR, do we need to update this?
+    // UICR pages are handled separately by checkUicr/repairUicr.
     if (page.targetAddr >= 0x10000000) {
       return;
     }
@@ -202,7 +222,8 @@ export class PartialFlashing {
     data: string | Uint8Array | MemoryMap,
     updateProgress: ProgressCallback,
   ): Promise<boolean> {
-    const flashBytes = this.convertDataToPaddedBytes(data);
+    const memoryMap = this.toMemoryMap(data);
+    const { flashBytes, uicrEntries } = this.extractFlashAndUicr(memoryMap);
 
     const checksums = await this.getFlashChecksumsAsync();
     let aligned = pageAlignBlocks(flashBytes, 0, this.pageSize);
@@ -235,6 +256,12 @@ export class PartialFlashing {
         await this.fullFlashAsync(data, updateProgress);
         partial = false;
       }
+    }
+
+    // After partial flash, check UICR. Full flash writes UICR as part of
+    // the hex stream so doesn't need this.
+    if (partial && uicrEntries.length > 0) {
+      partial = await this.ensureUicr(data, uicrEntries, updateProgress);
     }
 
     this.log("Flashing complete");
@@ -291,37 +318,121 @@ export class PartialFlashing {
       return data;
     }
     if (data instanceof Uint8Array) {
-      return this.paddedBytesToHexString(data);
+      return MemoryMap.fromPaddedUint8Array(data).asHexString();
     }
     return data.asHexString();
   }
 
-  private convertDataToPaddedBytes(
-    data: string | Uint8Array | MemoryMap,
-  ): Uint8Array {
-    if (data instanceof Uint8Array) {
-      return data;
-    }
+  /**
+   * Parse the flash data into a MemoryMap (if not already one).
+   */
+  private toMemoryMap(data: string | Uint8Array | MemoryMap): MemoryMap {
     if (typeof data === "string") {
-      return this.hexStringToPaddedBytes(data);
+      return MemoryMap.fromHex(truncateHexAfterEof(data));
     }
-    return this.memoryMapToPaddedBytes(data);
+    if (data instanceof Uint8Array) {
+      return MemoryMap.fromPaddedUint8Array(data);
+    }
+    return data;
   }
 
-  private hexStringToPaddedBytes(hex: string): Uint8Array {
-    const m = MemoryMap.fromHex(truncateHexAfterEof(hex));
-    return this.memoryMapToPaddedBytes(m);
-  }
-
-  private paddedBytesToHexString(data: Uint8Array): string {
-    return MemoryMap.fromPaddedUint8Array(data).asHexString();
-  }
-
-  private memoryMapToPaddedBytes(memoryMap: MemoryMap): Uint8Array {
+  /**
+   * Extract padded flash bytes (main flash only) and UICR entries from a
+   * MemoryMap. Parses the data once for both.
+   */
+  private extractFlashAndUicr(memoryMap: MemoryMap): {
+    flashBytes: Uint8Array;
+    uicrEntries: UicrEntry[];
+  } {
     const flashSize = {
       V1: 256 * 1024,
       V2: 512 * 1024,
     }[this.boardVersion];
-    return memoryMap.slicePad(0, flashSize);
+    const flashBytes = memoryMap.slicePad(0, flashSize);
+
+    const uicrEntries: UicrEntry[] = [];
+    for (const [addr, block] of memoryMap) {
+      if (addr < UICR_BASE) continue;
+      for (let i = 0; i < block.length; i += 4) {
+        uicrEntries.push({
+          address: addr + i,
+          value: read32FromUInt8Array(block, i),
+        });
+      }
+    }
+    return { flashBytes, uicrEntries };
+  }
+
+  /**
+   * Check UICR and repair if needed after a partial flash.
+   *
+   * UICR bits can only be cleared (1→0) without erasing. If all mismatched
+   * bits only need 1→0, we can write directly on both V1 and V2.
+   * If any bit needs 0→1, an erase is required first:
+   *  - V2: erase via NVMC.ERASEUICR, then write
+   *  - V1: no independent UICR erase, fall back to full flash
+   *
+   * Returns true if we stayed on the partial flash path, false if we had
+   * to fall back to full flash.
+   */
+  private async ensureUicr(
+    data: string | Uint8Array | MemoryMap,
+    entries: UicrEntry[],
+    updateProgress: ProgressCallback,
+  ): Promise<boolean> {
+    let needsErase = false;
+    let hasMismatch = false;
+
+    for (const { address, value } of entries) {
+      const actual = await this.device.adi.readMem32(address);
+      if (actual === value) continue;
+      hasMismatch = true;
+
+      // Check if any bit needs to go from 0→1 (requires erase)
+      const canWriteInPlace = (actual & value) >>> 0 === value >>> 0;
+      this.log(
+        `UICR mismatch at 0x${address.toString(16)}: ` +
+          `device=0x${(actual >>> 0).toString(16)} ` +
+          `expected=0x${(value >>> 0).toString(16)}` +
+          (canWriteInPlace ? "" : " (needs erase)"),
+      );
+      if (!canWriteInPlace) {
+        needsErase = true;
+      }
+    }
+
+    if (!hasMismatch) {
+      return true;
+    }
+
+    if (needsErase && this.boardVersion === "V1") {
+      // V1 has no ERASEUICR — must do a full flash (chip erase).
+      this.log("UICR requires erase on V1, falling back to full flash.");
+      await this.fullFlashAsync(data, updateProgress);
+      return false;
+    }
+
+    if (needsErase) {
+      // V2: erase UICR via dedicated NVMC register
+      this.log("Erasing UICR");
+      await this.device.adi.writeMem32(NVMC_CONFIG, NVMC_CONFIG_EEN);
+      await this.device.adi.writeMem32(NVMC_ERASEUICR, 1);
+      while (((await this.device.adi.readMem32(NVMC_READY)) & 1) === 0) {
+        // Poll until ready
+      }
+    }
+
+    // Write UICR words
+    this.log("Writing UICR");
+    await this.device.adi.writeMem32(NVMC_CONFIG, NVMC_CONFIG_WEN);
+    for (const { address, value } of entries) {
+      await this.device.adi.writeMem32(address, value);
+      while (((await this.device.adi.readMem32(NVMC_READY)) & 1) === 0) {
+        // Poll until ready
+      }
+    }
+    await this.device.adi.writeMem32(NVMC_CONFIG, NVMC_CONFIG_REN);
+    this.log("UICR repair complete");
+    return true;
   }
 }

--- a/packages/microbit-connection/src/usb/partial-flashing.ts
+++ b/packages/microbit-connection/src/usb/partial-flashing.ts
@@ -46,6 +46,7 @@
  */
 
 import { Logging } from "../logging.js";
+import { waitFor } from "./arm-debug.js";
 import { BoardVersion, ProgressCallback, ProgressStage } from "../device.js";
 import { truncateHexAfterEof } from "../hex-util.js";
 import MemoryMap from "nrf-intel-hex";
@@ -412,14 +413,17 @@ export class PartialFlashing {
       return false;
     }
 
+    const waitNvmcReady = () =>
+      waitFor(
+        async () => ((await this.device.adi.readMem32(NVMC_READY)) & 1) === 1,
+      );
+
     if (needsErase) {
       // V2: erase UICR via dedicated NVMC register
       this.log("Erasing UICR");
       await this.device.adi.writeMem32(NVMC_CONFIG, NVMC_CONFIG_EEN);
       await this.device.adi.writeMem32(NVMC_ERASEUICR, 1);
-      while (((await this.device.adi.readMem32(NVMC_READY)) & 1) === 0) {
-        // Poll until ready
-      }
+      await waitNvmcReady();
     }
 
     // Write UICR words
@@ -427,9 +431,7 @@ export class PartialFlashing {
     await this.device.adi.writeMem32(NVMC_CONFIG, NVMC_CONFIG_WEN);
     for (const { address, value } of entries) {
       await this.device.adi.writeMem32(address, value);
-      while (((await this.device.adi.readMem32(NVMC_READY)) & 1) === 0) {
-        // Poll until ready
-      }
+      await waitNvmcReady();
     }
     await this.device.adi.writeMem32(NVMC_CONFIG, NVMC_CONFIG_REN);
     this.log("UICR repair complete");


### PR DESCRIPTION
## Problem

Partial flashing skips all addresses >= `0x10000000`, which means UICR (User Information Configuration Registers) is never written. This is normally fine because UICR doesn't change between flashes — but after an interrupted full flash, the device is left with erased UICR and a "dead" micro:bit that won't boot.

The sequence that triggers this:
1. Full flash begins → DAPLink's `flash_manager_init` does a chip erase (wiping all flash **and** UICR)
2. Flash is interrupted (error, disconnect, etc.)
3. Fallback partial flash completes main flash successfully but skips UICR
4. Device has correct program flash but blank UICR → bootloader address is gone → device won't boot

Future flashes may also be partial if most pages were written successfully leading to the situation described in #112.

## Solution

After every partial flash, `ensureUicr()` reads device UICR and compares it against the hex file:

- **No mismatch** → nothing to do (the common case, zero overhead beyond a few SWD reads)
- **Mismatch, only 1→0 bit changes needed** → write directly without erasing (works on both V1 and V2, since UICR bits can only be cleared)
- **Mismatch, 0→1 bit changes needed (V2)** → erase UICR via `NVMC.ERASEUICR`, then write
- **Mismatch, 0→1 bit changes needed (V1)** → no independent UICR erase exists, fall back to full flash

Also refactors hex data parsing: the old `convertDataToPaddedBytes` chain is replaced by `toMemoryMap()` + `extractFlashAndUicr()`, which parses the input once to produce both the flash byte array and UICR entries.

## Hardware test

Adds UICR recovery after interrupted full flash test to the hardware test suite. We re-flash the same hex and verify the device boots and produces serial output.

Fixes #112