### PR TITLE
Breaking: rationalise DeviceErrorCode values and error handling

### DIFF
--- a/apps/demo/src/demo.ts
+++ b/apps/demo/src/demo.ts
@@ -216,7 +216,7 @@ const createConnectSection = (): Section => {
     displayStatus(event.status);
   };
   const backgroundErrorListener = (event: BackgroundErrorData) => {
-    console.error("Handled error:", event.message);
+    console.error("Handled error:", event.error.code, event.error.message, event.event);
   };
   (connection as any).addEventListener("status", handleDisplayStatusChange);
   (connection as any).addEventListener(

--- a/packages/microbit-connection/src/async-util.ts
+++ b/packages/microbit-connection/src/async-util.ts
@@ -3,7 +3,13 @@
  *
  * SPDX-License-Identifier: MIT
  */
-export class TimeoutError extends Error {}
+import { DeviceError } from "./device.js";
+
+export class TimeoutError extends DeviceError {
+  constructor(message: string = "Timeout") {
+    super({ code: "timeout", message });
+  }
+}
 
 export class DisconnectError extends Error {
   constructor(message: string = "Disconnect") {

--- a/packages/microbit-connection/src/bluetooth/ble-error.ts
+++ b/packages/microbit-connection/src/bluetooth/ble-error.ts
@@ -1,0 +1,43 @@
+import { DeviceError, DeviceErrorCode } from "../device.js";
+
+/**
+ * Maps BLE errors from @capacitor-community/bluetooth-le (and Web Bluetooth)
+ * to DeviceError with an appropriate code.
+ */
+export const mapBleError = (e: unknown): DeviceError => {
+  if (e instanceof DeviceError) {
+    return e;
+  }
+
+  const message = e instanceof Error ? e.message : String(e);
+  let code: DeviceErrorCode = "connection-error";
+
+  if (e instanceof Error) {
+    // @capacitor-community/bluetooth-le error messages:
+    // https://github.com/capacitor-community/bluetooth-le/blob/main/ios/Plugin/DeviceManager.swift
+    // https://github.com/capacitor-community/bluetooth-le/blob/main/ios/Plugin/Device.swift
+    if (/timeout/i.test(message)) {
+      // BleClient throws plain Errors for its own timeouts:
+      // "Connection timeout", "Read timeout.", "Write timeout.",
+      // "Service discovery timeout.", "Disconnection timeout." etc.
+      code = "timeout";
+    } else if (/disconnect/i.test(message)) {
+      code = "device-disconnected";
+    } else if (/permission/i.test(message)) {
+      code = "permission-denied";
+    }
+  }
+
+  return new DeviceError({ code, message, cause: e });
+};
+
+/**
+ * Wraps an async operation so that any BLE error is mapped to a DeviceError.
+ */
+export async function withBleErrorMapping<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    throw mapBleError(e);
+  }
+}

--- a/packages/microbit-connection/src/bluetooth/connection.ts
+++ b/packages/microbit-connection/src/bluetooth/connection.ts
@@ -48,6 +48,7 @@ import {
   DeviceBondState,
 } from "./device-bond-state.js";
 import { TimeoutError } from "../async-util.js";
+import { withBleErrorMapping } from "./ble-error.js";
 
 type BleClientError = { message: string; errorMessage: string };
 
@@ -432,72 +433,80 @@ class MicrobitBluetoothConnectionImpl
 
   async getAccelerometerData(): Promise<AccelerometerData> {
     assertConnected(this.device);
-    return this.device.accelerometer.getData();
+    return withBleErrorMapping(() => this.device!.accelerometer.getData());
   }
 
   async getAccelerometerPeriod(): Promise<number> {
     assertConnected(this.device);
-    return this.device.accelerometer.getPeriod();
+    return withBleErrorMapping(() => this.device!.accelerometer.getPeriod());
   }
 
   async setAccelerometerPeriod(value: number): Promise<void> {
     assertConnected(this.device);
-    return this.device.accelerometer.setPeriod(value);
+    return withBleErrorMapping(() =>
+      this.device!.accelerometer.setPeriod(value),
+    );
   }
 
   async setLedText(text: string): Promise<void> {
     assertConnected(this.device);
-    return this.device.led.setText(text);
+    return withBleErrorMapping(() => this.device!.led.setText(text));
   }
 
   async getLedScrollingDelay(): Promise<number> {
     assertConnected(this.device);
-    return this.device.led.getScrollingDelay();
+    return withBleErrorMapping(() => this.device!.led.getScrollingDelay());
   }
 
   async setLedScrollingDelay(delayInMillis: number): Promise<void> {
     assertConnected(this.device);
-    await this.device.led.setScrollingDelay(delayInMillis);
+    return withBleErrorMapping(() =>
+      this.device!.led.setScrollingDelay(delayInMillis),
+    );
   }
 
   async getLedMatrix(): Promise<LedMatrix> {
     assertConnected(this.device);
-    return await this.device.led.getLedMatrix();
+    return withBleErrorMapping(() => this.device!.led.getLedMatrix());
   }
 
   async setLedMatrix(matrix: LedMatrix): Promise<void> {
     assertConnected(this.device);
-    await this.device.led.setLedMatrix(matrix);
+    return withBleErrorMapping(() => this.device!.led.setLedMatrix(matrix));
   }
 
   async getMagnetometerData(): Promise<MagnetometerData> {
     assertConnected(this.device);
-    return this.device.magnetometer.getData();
+    return withBleErrorMapping(() => this.device!.magnetometer.getData());
   }
 
   async getMagnetometerPeriod(): Promise<number> {
     assertConnected(this.device);
-    return this.device.magnetometer.getPeriod();
+    return withBleErrorMapping(() => this.device!.magnetometer.getPeriod());
   }
 
   async setMagnetometerPeriod(value: number): Promise<void> {
     assertConnected(this.device);
-    return this.device.magnetometer.setPeriod(value);
+    return withBleErrorMapping(() =>
+      this.device!.magnetometer.setPeriod(value),
+    );
   }
 
   async getMagnetometerBearing(): Promise<number> {
     assertConnected(this.device);
-    return this.device.magnetometer.getBearing();
+    return withBleErrorMapping(() => this.device!.magnetometer.getBearing());
   }
 
   async triggerMagnetometerCalibration(): Promise<void> {
     assertConnected(this.device);
-    await this.device.magnetometer.triggerCalibration();
+    return withBleErrorMapping(() =>
+      this.device!.magnetometer.triggerCalibration(),
+    );
   }
 
   async uartWrite(data: Uint8Array): Promise<void> {
     assertConnected(this.device);
-    await this.device.uart.writeData(data);
+    return withBleErrorMapping(() => this.device!.uart.writeData(data));
   }
 
   /**
@@ -529,7 +538,7 @@ class MicrobitBluetoothConnectionImpl
         const boardVersion = connection.boardVersion;
         if (!boardVersion) {
           throw new DeviceError({
-            code: "device-disconnected",
+            code: "connection-error",
             message: "No board version found",
           });
         }
@@ -542,7 +551,7 @@ class MicrobitBluetoothConnectionImpl
 
         if (!this.bleDevice) {
           throw new DeviceError({
-            code: "device-disconnected",
+            code: "connection-error",
             message: "No device",
           });
         }

--- a/packages/microbit-connection/src/bluetooth/device-wrapper.ts
+++ b/packages/microbit-connection/src/bluetooth/device-wrapper.ts
@@ -196,12 +196,6 @@ export class BluetoothDeviceWrapper implements Logging {
       if (e instanceof DeviceError) {
         throw e;
       }
-      if (e instanceof TimeoutError) {
-        throw new DeviceError({
-          code: "timeout-error",
-          message: e instanceof Error ? e.message : String(e),
-        });
-      }
       this.setBonded(false);
       if (
         // Error thrown in iOS only.
@@ -211,11 +205,13 @@ export class BluetoothDeviceWrapper implements Logging {
         throw new DeviceError({
           code: "pairing-information-lost",
           message: e.message,
+          cause: e,
         });
       }
       throw new DeviceError({
-        code: "bluetooth-connection-failed",
+        code: "connection-error",
         message: e instanceof Error ? e.message : String(e),
+        cause: e,
       });
     }
   }

--- a/packages/microbit-connection/src/bluetooth/flashing/flashing-full.ts
+++ b/packages/microbit-connection/src/bluetooth/flashing/flashing-full.ts
@@ -42,9 +42,10 @@ export async function fullFlash(
       } catch (e) {
         connection.error("Failed to request reboot to bootloader", e);
         throw new DeviceError({
-          code: "flash-full-failed",
+          code: "connection-error",
           message:
             e instanceof Error ? e.message : "Failed to reboot to bootloader",
+          cause: e,
         });
       }
 

--- a/packages/microbit-connection/src/bluetooth/flashing/flashing-partial.ts
+++ b/packages/microbit-connection/src/bluetooth/flashing/flashing-partial.ts
@@ -64,8 +64,9 @@ const partialFlash = async (
       throw e;
     }
     throw new DeviceError({
-      code: "flash-partial-failed",
+      code: "connection-error",
       message: e instanceof Error ? e.message : String(e),
+      cause: e,
     });
   }
 

--- a/packages/microbit-connection/src/bluetooth/flashing/nordic-dfu.ts
+++ b/packages/microbit-connection/src/bluetooth/flashing/nordic-dfu.ts
@@ -103,7 +103,7 @@ export async function flashDfu(
             case DfuState.DFU_ABORTED: {
               reject(
                 new DeviceError({
-                  code: "flash-cancelled",
+                  code: "aborted",
                   message: "Flash operation was cancelled",
                 }),
               );
@@ -118,7 +118,7 @@ export async function flashDfu(
             case DfuState.DFU_FAILED: {
               reject(
                 new DeviceError({
-                  code: "flash-full-failed",
+                  code: "connection-error",
                   message: "Full flash via DFU failed",
                 }),
               );
@@ -167,8 +167,9 @@ export async function flashDfu(
         connection.error(`DFU Error: ${error.message}`, error);
         reject(
           new DeviceError({
-            code: "flash-full-failed",
+            code: "connection-error",
             message: error.message || "Full flash via DFU failed",
+            cause: error,
           }),
         );
       }

--- a/packages/microbit-connection/src/bluetooth/services/accelerometer-service.ts
+++ b/packages/microbit-connection/src/bluetooth/services/accelerometer-service.ts
@@ -6,6 +6,7 @@ import {
   TypedServiceEventDispatcher,
 } from "../../service-events.js";
 import { profile } from "../profile.js";
+import { mapBleError } from "../ble-error.js";
 
 export class AccelerometerService implements Service {
   uuid = profile.accelerometer.id;
@@ -87,8 +88,8 @@ export class AccelerometerService implements Service {
         );
       } catch (e) {
         this.dispatchTypedEvent("backgrounderror", {
-          message: "Failed to start notifications",
-          error: e,
+          error: mapBleError(e),
+          event: type,
         });
       }
     }
@@ -106,8 +107,8 @@ export class AccelerometerService implements Service {
         );
       } catch (e) {
         this.dispatchTypedEvent("backgrounderror", {
-          message: "Failed to stop notifications",
-          error: e,
+          error: mapBleError(e),
+          event: type,
         });
       }
     }

--- a/packages/microbit-connection/src/bluetooth/services/button-service.ts
+++ b/packages/microbit-connection/src/bluetooth/services/button-service.ts
@@ -6,6 +6,7 @@ import {
   TypedServiceEvent,
   TypedServiceEventDispatcher,
 } from "../../service-events.js";
+import { mapBleError } from "../ble-error.js";
 
 export class ButtonService implements Service {
   uuid = profile.button.id;
@@ -38,8 +39,8 @@ export class ButtonService implements Service {
           );
         } catch (e) {
           this.dispatchTypedEvent("backgrounderror", {
-            message: "Failed to start notifications",
-            error: e,
+            error: mapBleError(e),
+            event: type,
           });
         }
       }
@@ -50,11 +51,18 @@ export class ButtonService implements Service {
     switch (type) {
       case "buttonachanged":
       case "buttonbchanged": {
-        await BleClient.stopNotifications(
-          this.deviceId,
-          profile.button.id,
-          this.characteristicForButtonEventType(type).id,
-        );
+        try {
+          await BleClient.stopNotifications(
+            this.deviceId,
+            profile.button.id,
+            this.characteristicForButtonEventType(type).id,
+          );
+        } catch (e) {
+          this.dispatchTypedEvent("backgrounderror", {
+            error: mapBleError(e),
+            event: type,
+          });
+        }
       }
     }
   }

--- a/packages/microbit-connection/src/bluetooth/services/device-information-service.ts
+++ b/packages/microbit-connection/src/bluetooth/services/device-information-service.ts
@@ -7,26 +7,18 @@ export class DeviceInformationService {
 
   async getBoardVersion(): Promise<BoardVersion> {
     const serviceMeta = profile.deviceInformation;
-    try {
-      const modelNumberBytes = await BleClient.read(
-        this.deviceId,
-        serviceMeta.id,
-        serviceMeta.characteristics.modelNumber.id,
-      );
-      const modelNumber = new TextDecoder().decode(modelNumberBytes);
-      if (modelNumber.toLowerCase() === "BBC micro:bit".toLowerCase()) {
-        return "V1";
-      }
-      if (
-        modelNumber.toLowerCase().includes("BBC micro:bit v2".toLowerCase())
-      ) {
-        return "V2";
-      }
-      throw new Error(`Unexpected model number ${modelNumber}`);
-    } catch (e) {
-      throw new Error(
-        `Could not read model number: ${e instanceof Error ? e.message : e}`,
-      );
+    const modelNumberBytes = await BleClient.read(
+      this.deviceId,
+      serviceMeta.id,
+      serviceMeta.characteristics.modelNumber.id,
+    );
+    const modelNumber = new TextDecoder().decode(modelNumberBytes);
+    if (modelNumber.toLowerCase() === "BBC micro:bit".toLowerCase()) {
+      return "V1";
     }
+    if (modelNumber.toLowerCase().includes("BBC micro:bit v2".toLowerCase())) {
+      return "V2";
+    }
+    throw new Error(`Unexpected model number: ${modelNumber}`);
   }
 }

--- a/packages/microbit-connection/src/bluetooth/services/magnetometer-service.ts
+++ b/packages/microbit-connection/src/bluetooth/services/magnetometer-service.ts
@@ -6,6 +6,7 @@ import {
   TypedServiceEvent,
   TypedServiceEventDispatcher,
 } from "../../service-events.js";
+import { mapBleError } from "../ble-error.js";
 
 export class MagnetometerService implements Service {
   uuid = profile.magnetometer.id;
@@ -98,8 +99,8 @@ export class MagnetometerService implements Service {
         );
       } catch (e) {
         this.dispatchTypedEvent("backgrounderror", {
-          message: "Failed to start notifications",
-          error: e,
+          error: mapBleError(e),
+          event: type,
         });
       }
     }
@@ -115,8 +116,8 @@ export class MagnetometerService implements Service {
         );
       } catch (e) {
         this.dispatchTypedEvent("backgrounderror", {
-          message: "Failed to stop notifications",
-          error: e,
+          error: mapBleError(e),
+          event: type,
         });
       }
     }

--- a/packages/microbit-connection/src/bluetooth/services/uart-service.ts
+++ b/packages/microbit-connection/src/bluetooth/services/uart-service.ts
@@ -5,6 +5,7 @@ import {
   TypedServiceEvent,
   TypedServiceEventDispatcher,
 } from "../../service-events.js";
+import { mapBleError } from "../ble-error.js";
 
 export class UARTService implements Service {
   uuid = profile.uart.id;
@@ -33,8 +34,8 @@ export class UARTService implements Service {
         );
       } catch (e) {
         this.dispatchTypedEvent("backgrounderror", {
-          message: "Failed to start notifications",
-          error: e,
+          error: mapBleError(e),
+          event: type,
         });
       }
     }
@@ -42,11 +43,18 @@ export class UARTService implements Service {
 
   async stopNotifications(type: TypedServiceEvent): Promise<void> {
     if (type === "uartdata") {
-      await BleClient.stopNotifications(
-        this.deviceId,
-        profile.uart.id,
-        profile.uart.characteristics.tx.id,
-      );
+      try {
+        await BleClient.stopNotifications(
+          this.deviceId,
+          profile.uart.id,
+          profile.uart.characteristics.tx.id,
+        );
+      } catch (e) {
+        this.dispatchTypedEvent("backgrounderror", {
+          error: mapBleError(e),
+          event: type,
+        });
+      }
     }
   }
 

--- a/packages/microbit-connection/src/device.ts
+++ b/packages/microbit-connection/src/device.ts
@@ -17,91 +17,109 @@ export type ConnectionAvailabilityStatus =
   | "location-disabled";
 
 /**
- * Specific identified error types.
+ * Error codes identifying specific failure modes.
  *
- * New members may be added over time.
+ * Each code represents a distinct category of failure that apps can
+ * match on to decide what message to show or what recovery to attempt.
+ * New codes may be added in future minor releases.
+ *
+ * Codes are annotated with **USB**, **BLE**, or **USB, BLE** to indicate
+ * which connection types can produce them. USB-only apps can ignore
+ * BLE-only codes.
  */
 export type DeviceErrorCode =
+  // -- User cancelled (no error UI needed) --
+
   /**
-   * Operation was aborted via an AbortSignal.
+   * **BLE.** The operation was cancelled via an {@link AbortSignal}
+   * supplied by the caller. No user-facing error is needed.
    */
   | "aborted"
   /**
-   * Device not selected, e.g. because the user cancelled the dialog.
+   * **USB, BLE.** The user dismissed the device-picker dialog without
+   * selecting a device. Typically no error message is needed — the user
+   * chose not to proceed.
    */
   | "no-device-selected"
+
+  // -- Pre-connection / availability --
+
   /**
-   * Device not found, perhaps because it doesn't have new enough firmware (for V1).
-   */
-  | "update-req"
-  /**
-   * Unable to claim the interface, usually because it's in use in another tab/window.
-   */
-  | "clear-connect"
-  /**
-   * The device was found to be disconnected.
-   */
-  | "device-disconnected"
-  /**
-   * A communication timeout occurred.
-   */
-  | "timeout-error"
-  /**
-   * This is the fallback error case suggesting that the user physically reconnects their device.
-   */
-  | "reconnect-microbit"
-  /**
-   * An operation was attempted that requires an active connection.
-   */
-  | "not-connected"
-  /**
-   * Error occured during serial or bluetooth communication.
-   */
-  | "background-comms-error"
-  /**
-   * Bluetooth service is missing on device.
-   */
-  | "service-missing"
-  /**
-   * Failed to establish Bluetooth connection.
-   */
-  | "bluetooth-connection-failed"
-  /**
-   * Pairing information lost on micro:bit.
-   */
-  | "pairing-information-lost"
-  /**
-   * Partial flash operation failed.
-   */
-  | "flash-partial-failed"
-  /**
-   * Full flash operation failed.
-   */
-  | "flash-full-failed"
-  /**
-   * Flash operation was cancelled.
-   */
-  | "flash-cancelled"
-  /**
-   * Connection type is not supported on this platform/browser.
-   * Aligns with ConnectionAvailabilityStatus "unsupported".
+   * **USB, BLE.** The connection type is not supported on this platform
+   * or browser. Corresponds to {@link ConnectionAvailabilityStatus}
+   * `"unsupported"`.
    */
   | "unsupported"
   /**
-   * Connection is disabled (e.g., Bluetooth turned off).
-   * Aligns with ConnectionAvailabilityStatus "disabled".
+   * **BLE.** Bluetooth is turned off at the OS level. Prompt the user
+   * to enable it in system settings. Corresponds to
+   * {@link ConnectionAvailabilityStatus} `"disabled"`.
    */
   | "disabled"
   /**
-   * Required permissions were denied.
-   * Aligns with ConnectionAvailabilityStatus "permission-denied".
+   * **BLE.** The app does not have the required Bluetooth permissions
+   * (iOS/Android). Prompt the user to grant permission in system
+   * settings. Corresponds to {@link ConnectionAvailabilityStatus}
+   * `"permission-denied"`.
    */
   | "permission-denied"
   /**
-   * Location services are disabled (Android < 12 only).
-   * Aligns with ConnectionAvailabilityStatus "location-disabled".
+   * **BLE.** Location services are disabled. Required on Android
+   * versions before 12 for Bluetooth scanning. Prompt the user to
+   * enable location in system settings. Corresponds to
+   * {@link ConnectionAvailabilityStatus} `"location-disabled"`.
    */
-  | "location-disabled";
+  | "location-disabled"
+
+  // -- Connection state --
+
+  /**
+   * **USB, BLE.** A method was called that requires an active
+   * connection, but no connection is currently open. Call
+   * {@link DeviceConnection.connect} first.
+   */
+  | "not-connected"
+  /**
+   * **USB.** The USB interface could not be claimed, usually because
+   * another browser tab or application already has an open connection
+   * to the device.
+   */
+  | "device-in-use"
+
+  // -- Runtime communication failures --
+
+  /**
+   * **USB, BLE.** The device disconnected during an operation.
+   * The physical USB or Bluetooth connection was lost.
+   */
+  | "device-disconnected"
+  /**
+   * **USB, BLE.** A communication timeout — the device did not respond
+   * within the expected time. This may indicate the device is busy,
+   * hung, or that the connection is degraded.
+   */
+  | "timeout"
+  /**
+   * **USB, BLE.** A communication failure that does not match any more
+   * specific code. Typical handling: prompt the user to physically
+   * disconnect and reconnect the device, then retry.
+   */
+  | "connection-error"
+
+  // -- Device-specific --
+
+  /**
+   * **USB.** The USB device was found but lacks the expected CMSIS-DAP
+   * interface. On micro:bit V1 this indicates the DAPLink firmware is
+   * too old and needs updating.
+   */
+  | "firmware-update-required"
+  /**
+   * **BLE.** The micro:bit's Bluetooth pairing/bonding information has
+   * been lost (e.g. after a firmware reflash). The user needs to
+   * re-pair the device. Currently only detected on iOS.
+   */
+  | "pairing-information-lost";
 
 /**
  * Stages reported by the progress callback during connection and flashing.
@@ -159,8 +177,16 @@ export type ProgressCallback = (
  */
 export class DeviceError extends Error {
   code: DeviceErrorCode;
-  constructor({ code, message }: { code: DeviceErrorCode; message?: string }) {
-    super(message);
+  constructor({
+    code,
+    message,
+    cause,
+  }: {
+    code: DeviceErrorCode;
+    message?: string;
+    cause?: unknown;
+  }) {
+    super(message, { cause });
     this.code = code;
   }
 }
@@ -269,8 +295,8 @@ export interface ConnectionStatusChange {
 }
 
 export interface BackgroundErrorData {
-  message: string;
-  error?: unknown;
+  error: DeviceError;
+  event?: string;
 }
 
 export interface DeviceConnectionEventMap {

--- a/packages/microbit-connection/src/radio-bridge/connection.ts
+++ b/packages/microbit-connection/src/radio-bridge/connection.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  BackgroundErrorData,
   BoardVersion,
   ConnectionAvailabilityStatus,
   ConnectionStatus,
@@ -19,7 +20,7 @@ import {
   ServiceConnectionEventMap,
   TypedServiceEventDispatcher,
 } from "../service-events.js";
-import { SerialData, SerialErrorData } from "../usb/serial-events.js";
+import { SerialData } from "../usb/serial-events.js";
 import * as protocol from "./serial-protocol.js";
 import { MicrobitUSBConnection } from "../usb/connection.js";
 
@@ -259,7 +260,7 @@ class RadioBridgeSerialSession {
   private lastReceivedMessageTimestamp: number | undefined;
   private connectionCheckIntervalId: ReturnType<typeof setInterval> | undefined;
 
-  private serialErrorListener = (event: SerialErrorData) => {
+  private backgroundErrorListener = (event: BackgroundErrorData) => {
     this.logging.error("Serial error", event.error);
     void this.dispose();
   };
@@ -331,7 +332,10 @@ class RadioBridgeSerialSession {
 
   async connect() {
     this.delegate.addEventListener("serialdata", this.serialDataListener);
-    this.delegate.addEventListener("serialerror", this.serialErrorListener);
+    this.delegate.addEventListener(
+      "backgrounderror",
+      this.backgroundErrorListener,
+    );
     try {
       this.callbacks.onConnecting();
       await this.handshake();
@@ -392,7 +396,10 @@ class RadioBridgeSerialSession {
     }
     this.responseMap.clear();
     this.delegate.removeEventListener("serialdata", this.serialDataListener);
-    this.delegate.removeEventListener("serialerror", this.serialErrorListener);
+    this.delegate.removeEventListener(
+      "backgrounderror",
+      this.backgroundErrorListener,
+    );
     if (disconnect) {
       await this.delegate.disconnect();
     }

--- a/packages/microbit-connection/src/usb/arm-debug.ts
+++ b/packages/microbit-connection/src/usb/arm-debug.ts
@@ -130,7 +130,7 @@ export async function waitFor(
     if (await fn()) return;
     if (deadline && Date.now() > deadline) {
       throw new DeviceError({
-        code: "timeout-error",
+        code: "timeout",
         message: "Wait timed out",
       });
     }

--- a/packages/microbit-connection/src/usb/cmsis-dap.ts
+++ b/packages/microbit-connection/src/usb/cmsis-dap.ts
@@ -108,7 +108,7 @@ export interface DapOperation {
  */
 export class DapError extends DeviceError {
   constructor(message: string) {
-    super({ code: "reconnect-microbit", message });
+    super({ code: "connection-error", message });
   }
 }
 

--- a/packages/microbit-connection/src/usb/connection.ts
+++ b/packages/microbit-connection/src/usb/connection.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { TimeoutError, withTimeout } from "../async-util.js";
+import { withTimeout } from "../async-util.js";
 import { throwIfUnavailable } from "../availability.js";
 import {
   BoardVersion,
@@ -344,7 +344,7 @@ class MicrobitUSBConnectionImpl
     await this.connectInternal(progress);
     if (!this.device) {
       throw new DeviceError({
-        code: "device-disconnected",
+        code: "connection-error",
         message: "Must be connected now",
       });
     }
@@ -447,7 +447,10 @@ class MicrobitUSBConnectionImpl
           this.log("Finished listening for serial data");
         })
         .catch((e) => {
-          this.dispatchEvent("serialerror", { error: e });
+          this.dispatchEvent("backgrounderror", {
+            error: enrichedError(e),
+            event: "serialdata",
+          });
         })
         .finally(() => {
           this.serialState = false;
@@ -792,12 +795,6 @@ const enrichedError = (err: any): DeviceError => {
   if (err instanceof DeviceError) {
     return err;
   }
-  if (err instanceof TimeoutError) {
-    return new DeviceError({
-      code: "timeout-error",
-      message: err.message,
-    });
-  }
 
   if (err instanceof Error) {
     // Match Chromium WebUSB DOMException messages for user-friendly error codes.
@@ -807,25 +804,29 @@ const enrichedError = (err: any): DeviceError => {
       return new DeviceError({
         code: "no-device-selected",
         message: err.message,
+        cause: err,
       });
     }
     // https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/modules/webusb/usb_device.cc
     if (/Unable to claim interface/.test(err.message)) {
       return new DeviceError({
-        code: "clear-connect",
+        code: "device-in-use",
         message: err.message,
+        cause: err,
       });
     }
     if (/The device was disconnected/.test(err.message)) {
       return new DeviceError({
         code: "device-disconnected",
         message: err.message,
+        cause: err,
       });
     }
   }
   return new DeviceError({
-    code: "reconnect-microbit",
+    code: "connection-error",
     message: err.message,
+    cause: err,
   });
 };
 

--- a/packages/microbit-connection/src/usb/index.ts
+++ b/packages/microbit-connection/src/usb/index.ts
@@ -7,8 +7,4 @@ export {
   type MicrobitUSBConnection,
   type MicrobitUSBConnectionOptions,
 } from "./connection.js";
-export type {
-  SerialConnectionEventMap,
-  SerialData,
-  SerialErrorData,
-} from "./serial-events.js";
+export type { SerialConnectionEventMap, SerialData } from "./serial-events.js";

--- a/packages/microbit-connection/src/usb/serial-events.ts
+++ b/packages/microbit-connection/src/usb/serial-events.ts
@@ -2,10 +2,6 @@ export interface SerialData {
   data: string;
 }
 
-export interface SerialErrorData {
-  error: unknown;
-}
-
 export interface SerialConnectionEventMap {
   /** Fired when serial data is received from the micro:bit. */
   serialdata: SerialData;
@@ -18,6 +14,4 @@ export interface SerialConnectionEventMap {
    * program continues running and serial resumes when the tab becomes visible.
    */
   serialreset: void;
-  /** Fired when a serial read error occurs. */
-  serialerror: SerialErrorData;
 }

--- a/packages/microbit-connection/src/usb/transport.ts
+++ b/packages/microbit-connection/src/usb/transport.ts
@@ -66,7 +66,7 @@ export class UsbTransport implements Transport {
 
     if (!interfaces.length) {
       throw new DeviceError({
-        code: "update-req",
+        code: "firmware-update-required",
         message: "No valid interfaces found.",
       });
     }
@@ -103,7 +103,7 @@ export class UsbTransport implements Transport {
   async read(): Promise<DataView> {
     if (this.interfaceNumber === undefined) {
       throw new DeviceError({
-        code: "reconnect-microbit",
+        code: "connection-error",
         message: "No device opened",
       });
     }
@@ -129,7 +129,7 @@ export class UsbTransport implements Transport {
     }
     if (result.status !== "ok" || !result.data) {
       throw new DeviceError({
-        code: "reconnect-microbit",
+        code: "connection-error",
         message: "USB read failed",
       });
     }
@@ -139,7 +139,7 @@ export class UsbTransport implements Transport {
   async write(data: Uint8Array): Promise<void> {
     if (this.interfaceNumber === undefined) {
       throw new DeviceError({
-        code: "reconnect-microbit",
+        code: "connection-error",
         message: "No device opened",
       });
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2021",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
Review all DeviceErrorCode values for consistency and consolidate error handling patterns ahead of v1.0.

Error code renames (DeviceErrorCode string values) and removals.

Flash errors now propagate the underlying cause (e.g. "timeout", "device-disconnected", "connection-error") rather than wrapping it in a flash-specific code. The caller already knows it was flashing and we didn't consistently use the flash failure codes for all types of error anyway.

DeviceError constructor now accepts an optional `cause` parameter, threaded through all error-wrapping sites to preserve the original error chain for debugging. Bumped tsconfig lib from ES2020 to ES2022 for the ErrorOptions type.

BackgroundErrorData changed from { message: string; error?: unknown } to { error: DeviceError; event?: string }. The error is now always a structured DeviceError rather than an opaque value.

Removed SerialErrorData and the "serialerror" event from USB connections. Serial errors are now reported via the unified "backgrounderror" event with a DeviceError.

TimeoutError (async-util.ts) now extends DeviceError with code "timeout" instead of extending plain Error.

BLE service methods on the connection are now wrapped with withBleErrorMapping so BLE errors are mapped to DeviceError before reaching consumers.

Migration guide for apps checking error codes:

  // Before → After
  error.code === "reconnect-microbit"        → "connection-error"
  error.code === "timeout-error"             → "timeout"
  error.code === "update-req"                → "firmware-update-required"
  error.code === "clear-connect"             → "device-in-use"
  error.code === "flash-cancelled"           → "aborted"
  error.code === "bluetooth-connection-failed" → "connection-error"
  error.code === "background-comms-error"    → "connection-error"
  error.code === "service-missing"           → "connection-error"
  error.code === "flash-partial-failed"      → (removed, see below)
  error.code === "flash-full-failed"         → (removed, see below)

  // BackgroundErrorData
  event.message        → event.error.message
  event.error          → event.error (now always DeviceError)
  event.error?.message → event.error.message

  // Serial errors
  connection.addEventListener("serialerror", ...) →
    connection.addEventListener("backgrounderror", ...)