### PR TITLE
Add bondMode option to ConnectOptions for native BLE

### DIFF
--- a/apps/demo/src/components/ConnectionHeader.tsx
+++ b/apps/demo/src/components/ConnectionHeader.tsx
@@ -1,4 +1,4 @@
-import { ConnectionStatus } from "@microbit/microbit-connection";
+import { ConnectionStatus, type BondMode } from "@microbit/microbit-connection";
 import { Capacitor } from "@capacitor/core";
 import { useConnection, type AnyConnection } from "../hooks/use-connection.ts";
 import { useErrorDialog } from "../hooks/use-error-dialog.ts";
@@ -27,6 +27,8 @@ const ConnectionHeader = () => {
     setConnectionType,
     pauseOnHidden,
     setPauseOnHidden,
+    bondMode,
+    setBondMode,
   } = useConnection();
   const { showError } = useErrorDialog();
   const isNative = Capacitor.isNativePlatform();
@@ -65,7 +67,7 @@ const ConnectionHeader = () => {
         </button>
       ) : (
         <button
-          onClick={() => connection.connect().catch(showError)}
+          onClick={() => connection.connect({ bondMode }).catch(showError)}
           disabled={status === ConnectionStatus.Connecting}
           className="btn btn-primary"
         >
@@ -102,6 +104,22 @@ const ConnectionHeader = () => {
           <span className="version-badge">{boardVersion}</span>
         )}
       </div>
+
+      {connection.type === "bluetooth" && isNative && (
+        <label style={{ fontSize: 12, display: "flex", alignItems: "center", gap: 4 }}>
+          Bond:
+          <select
+            value={bondMode}
+            onChange={(e) => setBondMode(e.target.value as BondMode)}
+            className="select"
+            style={{ fontSize: 12 }}
+          >
+            <option value="application">Application</option>
+            <option value="pairing">Pairing</option>
+            <option value="none">None</option>
+          </select>
+        </label>
+      )}
 
       {(connection.type === "usb" || connection.type === "radio-bridge") && (
         <label style={{ fontSize: 12, display: "flex", alignItems: "center", gap: 4 }}>

--- a/apps/demo/src/hooks/use-connection.ts
+++ b/apps/demo/src/hooks/use-connection.ts
@@ -1,5 +1,6 @@
 import {
   ConnectionStatus,
+  type BondMode,
   type ConnectionStatusChange,
   type BackgroundErrorData,
   type BoardVersion,
@@ -38,6 +39,8 @@ interface ConnectionContextValue {
   setConnectionType: (type: AnyConnection["type"]) => void;
   pauseOnHidden: boolean;
   setPauseOnHidden: (v: boolean) => void;
+  bondMode: BondMode;
+  setBondMode: (v: BondMode) => void;
 }
 
 export const ConnectionContext = createContext<
@@ -48,6 +51,7 @@ export const useConnectionState = (): ConnectionContextValue | undefined => {
   const { log } = useLog();
   const [connectionType, setConnectionType] = useState<AnyConnection["type"]>(defaultConnectionType);
   const [pauseOnHidden, setPauseOnHidden] = useState(true);
+  const [bondMode, setBondMode] = useState<BondMode>("application");
   const [status, setStatus] = useState<ConnectionStatus>(
     ConnectionStatus.NoAuthorizedDevice,
   );
@@ -134,6 +138,8 @@ export const useConnectionState = (): ConnectionContextValue | undefined => {
     setConnectionType,
     pauseOnHidden,
     setPauseOnHidden,
+    bondMode,
+    setBondMode,
   };
 };
 

--- a/apps/demo/src/hooks/use-connection.ts
+++ b/apps/demo/src/hooks/use-connection.ts
@@ -51,7 +51,7 @@ export const useConnectionState = (): ConnectionContextValue | undefined => {
   const { log } = useLog();
   const [connectionType, setConnectionType] = useState<AnyConnection["type"]>(defaultConnectionType);
   const [pauseOnHidden, setPauseOnHidden] = useState(true);
-  const [bondMode, setBondMode] = useState<BondMode>("application");
+  const [bondMode, setBondMode] = useState<BondMode>("pairing");
   const [status, setStatus] = useState<ConnectionStatus>(
     ConnectionStatus.NoAuthorizedDevice,
   );

--- a/packages/microbit-connection/src/bluetooth/connection.ts
+++ b/packages/microbit-connection/src/bluetooth/connection.ts
@@ -592,7 +592,11 @@ class MicrobitBluetoothConnectionImpl
       this.deferredUpdatesPreviousStatus = this.status;
 
       if (this.status !== ConnectionStatus.Connected) {
-        await this.connect({ progress, signal: options.signal });
+        await this.connect({
+          progress,
+          signal: options.signal,
+          bondMode: "pairing",
+        });
       }
 
       const connection = this.device!;

--- a/packages/microbit-connection/src/bluetooth/device-wrapper.ts
+++ b/packages/microbit-connection/src/bluetooth/device-wrapper.ts
@@ -180,7 +180,7 @@ export class BluetoothDeviceWrapper implements Logging {
     });
     this.callbacks.onConnecting();
 
-    const bondMode: BondMode = options?.bondMode ?? "application";
+    const bondMode: BondMode = options?.bondMode ?? "pairing";
     try {
       if (Capacitor.isNativePlatform() && bondMode !== "none") {
         const isBonded = this.deviceBondState.isBonded(this.bleDevice.deviceId);

--- a/packages/microbit-connection/src/bluetooth/device-wrapper.ts
+++ b/packages/microbit-connection/src/bluetooth/device-wrapper.ts
@@ -20,6 +20,7 @@ import {
 import { ButtonService } from "./services/button-service.js";
 import { DeviceInformationService } from "./services/device-information-service.js";
 import {
+  BondMode,
   BoardVersion,
   ConnectOptions,
   DeviceError,
@@ -160,10 +161,11 @@ export class BluetoothDeviceWrapper implements Logging {
     });
     this.callbacks.onConnecting();
 
+    const bondMode: BondMode = options?.bondMode ?? "application";
     try {
-      if (Capacitor.isNativePlatform()) {
+      if (Capacitor.isNativePlatform() && bondMode !== "none") {
         const isBonded = this.deviceBondState.isBonded(this.bleDevice.deviceId);
-        await this.connectHandlingBond(progress, isBonded ?? false);
+        await this.connectHandlingBond(progress, isBonded ?? false, bondMode);
         this.setBonded(true);
         // We need this on Android for reconnecting after DFU.
         await BleClient.discoverServices(this.bleDevice.deviceId);
@@ -455,6 +457,7 @@ export class BluetoothDeviceWrapper implements Logging {
   private async connectHandlingBond(
     progress: ProgressCallback,
     isAlreadyIosBonded: boolean,
+    bondMode: "pairing" | "application",
   ): Promise<void> {
     progress(ProgressStage.CheckingBond);
     const startTime = Date.now();
@@ -488,10 +491,14 @@ export class BluetoothDeviceWrapper implements Logging {
       await this.connectInternal();
 
       try {
+        const targetMode =
+          bondMode === "pairing"
+            ? MicroBitMode.Pairing
+            : MicroBitMode.Application;
         progress(ProgressStage.ResettingDevice);
-        this.log("Resetting to pairing mode");
+        this.log(`Resetting to ${bondMode} mode`);
         const pf = new PartialFlashingService(this);
-        await pf.resetToMode(MicroBitMode.Pairing);
+        await pf.resetToMode(targetMode);
         await this.waitForDisconnect(10_000);
 
         progress(ProgressStage.Connecting);

--- a/packages/microbit-connection/src/device.ts
+++ b/packages/microbit-connection/src/device.ts
@@ -265,7 +265,7 @@ export interface ConnectOptions {
   signal?: AbortSignal;
   /**
    * Controls bonding and post-bond device mode on native platforms.
-   * Ignored on web. Default: `"application"`.
+   * Ignored on web. Default: `"pairing"`.
    *
    * @see {@link BondMode}
    */

--- a/packages/microbit-connection/src/device.ts
+++ b/packages/microbit-connection/src/device.ts
@@ -233,6 +233,21 @@ export const ConnectionStatus = {
 export type ConnectionStatus =
   (typeof ConnectionStatus)[keyof typeof ConnectionStatus];
 
+/**
+ * Controls bonding behaviour and post-bond device mode on native platforms.
+ *
+ * - `"pairing"` — Bond if needed, then reset the device into pairing mode.
+ *   Use when you intend to flash immediately after connecting.
+ * - `"application"` — Bond if needed, then reset the device into application
+ *   mode. Use when you want to interact with BLE services (sensors, UART, …)
+ *   on firmware that has BLE enabled in application mode.
+ * - `"none"` — Skip bonding entirely and just connect. Use for open-link
+ *   firmware where no bonding is required.
+ *
+ * Ignored on web platforms where the browser manages pairing transparently.
+ */
+export type BondMode = "pairing" | "application" | "none";
+
 export interface ConnectOptions {
   /**
    * Optional progress callback for tracking connection stages.
@@ -248,6 +263,13 @@ export interface ConnectOptions {
    * aborted programmatically.
    */
   signal?: AbortSignal;
+  /**
+   * Controls bonding and post-bond device mode on native platforms.
+   * Ignored on web. Default: `"application"`.
+   *
+   * @see {@link BondMode}
+   */
+  bondMode?: BondMode;
 }
 
 export interface FlashOptions {

--- a/packages/microbit-connection/src/index.ts
+++ b/packages/microbit-connection/src/index.ts
@@ -4,6 +4,7 @@
 import {
   BackgroundErrorData,
   BoardVersion,
+  BondMode,
   ConnectOptions,
   ConnectionAvailabilityStatus,
   ConnectionStatus,
@@ -42,6 +43,7 @@ export type {
   AccelerometerData,
   BackgroundErrorData,
   BoardVersion,
+  BondMode,
   ButtonData,
   ButtonEventType,
   ConnectOptions,


### PR DESCRIPTION
The native connect() flow previously assumed the caller intended to flash: after a new bond it always reset the device into pairing mode. This is wrong for two other common scenarios:

1. BLE-enabled firmware, interact with services (sensors, UART, LEDs): The device should end up in application mode, not pairing mode. bondMode: "application" handles this — it still bonds if needed (required to get past the firmware whitelist on first connection) but resets to application mode instead of pairing mode.

2. Open-link firmware, no bonding needed: bondMode: "none" skips createBond() on Android and the iOS pairing trigger entirely, avoiding an unnecessary pairing dialog and the 15s post-bond firmware reset.

The default for connect() is "pairing". flash() explicitly passes bondMode: "pairing" internally, so the flash flow is unchanged.

On web, bondMode is ignored — the browser manages pairing transparently via the OS when accessing encrypted characteristics (well, so Claude claims, we need more practical experience here). But either way we for sure can't trigger it.

The demo app gains a Bond mode selector (native Bluetooth only) to exercise all three modes.

Fixes https://github.com/microbit-foundation/microbit-connection/issues/118