### PR TITLE
Add event service for gestures, button actions, and raw message bus events

### DIFF
--- a/apps/demo/src/App.css
+++ b/apps/demo/src/App.css
@@ -203,6 +203,12 @@
   padding: 8px 0;
 }
 
+.service-note {
+  color: #737373;
+  font-size: 12px;
+  margin: 0 0 4px;
+}
+
 /* Header */
 .app-header {
   display: flex;

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -17,15 +17,17 @@ import LedsTab from "./components/LedsTab.tsx";
 import SerialTab from "./components/SerialTab.tsx";
 import UartTab from "./components/UartTab.tsx";
 import PinsTab from "./components/PinsTab.tsx";
+import EventsTab from "./components/EventsTab.tsx";
 import "./App.css";
 
-type Tab = "flash" | "sensors" | "io" | "pins" | "serial" | "uart";
+type Tab = "flash" | "sensors" | "io" | "pins" | "events" | "serial" | "uart";
 
 const tabDefs: { id: Tab; label: string; availableFor: string[] }[] = [
   { id: "flash", label: "Flash", availableFor: ["usb", "bluetooth"] },
   { id: "sensors", label: "Sensors", availableFor: ["bluetooth", "radio-bridge"] },
   { id: "io", label: "LEDs", availableFor: ["bluetooth"] },
   { id: "pins", label: "Pins", availableFor: ["bluetooth"] },
+  { id: "events", label: "Events", availableFor: ["bluetooth"] },
   { id: "serial", label: "Serial", availableFor: ["usb"] },
   { id: "uart", label: "UART", availableFor: ["bluetooth"] },
 ];
@@ -35,6 +37,7 @@ const tabComponents: Record<Tab, React.ComponentType> = {
   sensors: SensorsTab,
   io: LedsTab,
   pins: PinsTab,
+  events: EventsTab,
   serial: SerialTab,
   uart: UartTab,
 };

--- a/apps/demo/src/components/EventsTab.tsx
+++ b/apps/demo/src/components/EventsTab.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import type {
+  GestureData,
+  ButtonActionData,
+  MicrobitEventData,
+} from "@microbit/microbit-connection";
+import { GestureEvent, ButtonAction } from "@microbit/microbit-connection";
+import type { MicrobitBluetoothConnection } from "@microbit/microbit-connection/bluetooth";
+import { useConnection } from "../hooks/use-connection.ts";
+import { useLog } from "../hooks/use-log.ts";
+import { useErrorDialog } from "../hooks/use-error-dialog.ts";
+
+const gestureNames: Record<number, string> = {
+  [GestureEvent.TiltUp]: "Tilt up",
+  [GestureEvent.TiltDown]: "Tilt down",
+  [GestureEvent.TiltLeft]: "Tilt left",
+  [GestureEvent.TiltRight]: "Tilt right",
+  [GestureEvent.FaceUp]: "Face up",
+  [GestureEvent.FaceDown]: "Face down",
+  [GestureEvent.Freefall]: "Freefall",
+  [GestureEvent.Acceleration3g]: "3g",
+  [GestureEvent.Acceleration6g]: "6g",
+  [GestureEvent.Acceleration8g]: "8g",
+  [GestureEvent.Shake]: "Shake",
+  [GestureEvent.Acceleration2g]: "2g",
+};
+
+const buttonActionNames: Record<number, string> = {
+  [ButtonAction.Down]: "Down",
+  [ButtonAction.Up]: "Up",
+  [ButtonAction.Click]: "Click",
+  [ButtonAction.LongClick]: "Long click",
+  [ButtonAction.Hold]: "Hold",
+  [ButtonAction.DoubleClick]: "Double click",
+};
+
+const GestureSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
+  const [gesture, setGesture] = useState<string | null>(null);
+  const [listening, setListening] = useState(false);
+
+  useEffect(() => {
+    if (!listening) return;
+    const listener = (d: GestureData) => {
+      setGesture(gestureNames[d.gesture] ?? `Unknown (${d.gesture})`);
+    };
+    connection.addEventListener("gesturechanged", listener);
+    return () => {
+      connection.removeEventListener("gesturechanged", listener);
+    };
+  }, [connection, listening]);
+
+  return (
+    <div className="section">
+      <h2>Gestures</h2>
+      <div className="control-row">
+        <button
+          onClick={() => setListening(!listening)}
+          className={`btn${listening ? " btn-toggle active" : ""}`}
+        >
+          {listening ? "Stop" : "Listen"}
+        </button>
+      </div>
+      {gesture !== null ? (
+        <div className="sensor-readout">
+          <span className="axis">
+            <span className="axis-value" style={{ minWidth: 80 }}>
+              {gesture}
+            </span>
+          </span>
+        </div>
+      ) : (
+        <p className="empty-state">
+          {listening
+            ? "Shake or tilt the micro:bit..."
+            : "Press Listen to start receiving gesture events."}
+        </p>
+      )}
+    </div>
+  );
+};
+
+const ButtonClicksSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
+  const [lastA, setLastA] = useState("-");
+  const [lastB, setLastB] = useState("-");
+  const [lastAB, setLastAB] = useState("-");
+  const [lastLogo, setLastLogo] = useState("-");
+  const [listening, setListening] = useState(false);
+
+  useEffect(() => {
+    if (!listening) return;
+    const onA = (d: ButtonActionData) => {
+      setLastA(buttonActionNames[d.action] ?? String(d.action));
+    };
+    const onB = (d: ButtonActionData) => {
+      setLastB(buttonActionNames[d.action] ?? String(d.action));
+    };
+    const onAB = (d: ButtonActionData) => {
+      setLastAB(buttonActionNames[d.action] ?? String(d.action));
+    };
+    const onLogo = (d: ButtonActionData) => {
+      setLastLogo(buttonActionNames[d.action] ?? String(d.action));
+    };
+    connection.addEventListener("buttonaaction", onA);
+    connection.addEventListener("buttonbaction", onB);
+    connection.addEventListener("buttonabaction", onAB);
+    connection.addEventListener("logoaction", onLogo);
+    return () => {
+      connection.removeEventListener("buttonaaction", onA);
+      connection.removeEventListener("buttonbaction", onB);
+      connection.removeEventListener("buttonabaction", onAB);
+      connection.removeEventListener("logoaction", onLogo);
+    };
+  }, [connection, listening]);
+
+  return (
+    <div className="section">
+      <h2>Button Events</h2>
+      <div className="control-row">
+        <button
+          onClick={() => setListening(!listening)}
+          className={`btn${listening ? " btn-toggle active" : ""}`}
+        >
+          {listening ? "Stop" : "Listen"}
+        </button>
+      </div>
+      <div className="sensor-readout" style={{ marginTop: 8 }}>
+        <span className="axis">
+          <span className="axis-label">A:</span>
+          <span className="axis-value" style={{ minWidth: 80 }}>{lastA}</span>
+        </span>
+        <span className="axis">
+          <span className="axis-label">B:</span>
+          <span className="axis-value" style={{ minWidth: 80 }}>{lastB}</span>
+        </span>
+        <span className="axis">
+          <span className="axis-label">A+B:</span>
+          <span className="axis-value" style={{ minWidth: 80 }}>{lastAB}</span>
+        </span>
+        <span className="axis">
+          <span className="axis-label">Logo:</span>
+          <span className="axis-value" style={{ minWidth: 80 }}>{lastLogo}</span>
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const RawEventsSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
+  const { log } = useLog();
+  const { showError } = useErrorDialog();
+  const [listening, setListening] = useState(false);
+  const [source, setSource] = useState("0");
+  const [value, setValue] = useState("0");
+  const [entries, setEntries] = useState<string[]>([]);
+  const logRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!listening) return;
+    const listener = (d: MicrobitEventData) => {
+      setEntries((prev) => {
+        const next = [...prev, `source=${d.source} value=${d.value}`];
+        return next.length > 100 ? next.slice(-100) : next;
+      });
+    };
+    connection.addEventListener("microbitevent", listener);
+    return () => {
+      connection.removeEventListener("microbitevent", listener);
+    };
+  }, [connection, listening]);
+
+  useEffect(() => {
+    if (logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight;
+    }
+  }, [entries]);
+
+  const subscribe = useCallback(async () => {
+    try {
+      const s = parseInt(source, 10);
+      const v = parseInt(value, 10);
+      await connection.subscribeToEvent(s, v);
+      log("event", `Subscribed to source=${s} value=${v}`);
+    } catch (e) {
+      showError(e);
+    }
+  }, [connection, source, value, log, showError]);
+
+  return (
+    <div className="section">
+      <h2>Raw Events</h2>
+      <div className="control-row">
+        <button
+          onClick={() => setListening(!listening)}
+          className={`btn${listening ? " btn-toggle active" : ""}`}
+        >
+          {listening ? "Stop" : "Listen"}
+        </button>
+      </div>
+      <div className="control-row" style={{ marginTop: 8 }}>
+        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+          Source:
+          <input
+            type="number"
+            value={source}
+            onChange={(e) => setSource(e.target.value)}
+            className="input"
+            style={{ width: 60 }}
+          />
+        </label>
+        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+          Value:
+          <input
+            type="number"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="input"
+            style={{ width: 60 }}
+            placeholder="0 = any"
+          />
+        </label>
+        <button onClick={subscribe} className="btn">Subscribe</button>
+        <button onClick={() => setEntries([])} className="btn">Clear</button>
+      </div>
+      <div ref={logRef} className="data-box">
+        {entries.length > 0
+          ? entries.join("\n")
+          : listening
+            ? "Waiting for events..."
+            : "Listen and subscribe to see raw events."}
+      </div>
+    </div>
+  );
+};
+
+const SendEventSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
+  const { log } = useLog();
+  const { showError } = useErrorDialog();
+  const [source, setSource] = useState("");
+  const [value, setValue] = useState("");
+
+  const send = useCallback(async () => {
+    try {
+      const s = parseInt(source, 10);
+      const v = parseInt(value, 10);
+      await connection.sendEvent(s, v);
+      log("event", `Sent source=${s} value=${v}`);
+    } catch (e) {
+      showError(e);
+    }
+  }, [connection, source, value, log, showError]);
+
+  return (
+    <div className="section">
+      <h2>Send Event</h2>
+      <div className="control-row">
+        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+          Source:
+          <input
+            type="number"
+            value={source}
+            onChange={(e) => setSource(e.target.value)}
+            className="input"
+            style={{ width: 60 }}
+          />
+        </label>
+        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+          Value:
+          <input
+            type="number"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="input"
+            style={{ width: 60 }}
+          />
+        </label>
+        <button onClick={send} className="btn">Send</button>
+      </div>
+    </div>
+  );
+};
+
+const EventsTab = () => {
+  const { connection } = useConnection();
+
+  if (connection.type !== "bluetooth") {
+    return (
+      <div className="tab-page">
+        <div className="section">
+          <p className="empty-state">Events require a Bluetooth connection.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tab-page">
+      <p className="service-note">Requires: Event Service</p>
+      <GestureSection connection={connection} />
+      <ButtonClicksSection connection={connection} />
+      <RawEventsSection connection={connection} />
+      <SendEventSection connection={connection} />
+    </div>
+  );
+};
+
+export default EventsTab;

--- a/apps/demo/src/components/LedsTab.tsx
+++ b/apps/demo/src/components/LedsTab.tsx
@@ -138,6 +138,7 @@ const LedsTab = () => {
 
   return (
     <div className="tab-page">
+      <p className="service-note">Requires: LED Service</p>
       <TextSection connection={connection} />
       <ScrollingDelaySection connection={connection} />
       <MatrixSection connection={connection} />

--- a/apps/demo/src/components/PinsTab.tsx
+++ b/apps/demo/src/components/PinsTab.tsx
@@ -285,6 +285,7 @@ const PinsTab = () => {
 
   return (
     <div className="tab-page">
+      <p className="service-note">Requires: IO Pin Service</p>
       <PinConfigSection connection={connection} />
       <PinDataSection connection={connection} />
       <PwmSection connection={connection} />

--- a/apps/demo/src/components/SensorsTab.tsx
+++ b/apps/demo/src/components/SensorsTab.tsx
@@ -68,7 +68,7 @@ const AccelerometerSection = ({ connection }: { connection: ServiceConnection })
 
   return (
     <div className="section">
-      <h2>Accelerometer</h2>
+      <h2>Accelerometer Service</h2>
       <div className="control-row">
         <button
           onClick={() => setListening(!listening)}
@@ -150,7 +150,7 @@ const MagnetometerSection = ({ connection }: { connection: MicrobitBluetoothConn
 
   return (
     <div className="section">
-      <h2>Magnetometer</h2>
+      <h2>Magnetometer Service</h2>
       <div className="control-row">
         <button
           onClick={() => setListening(!listening)}
@@ -233,7 +233,7 @@ const TemperatureSection = ({ connection }: { connection: MicrobitBluetoothConne
 
   return (
     <div className="section">
-      <h2>Temperature</h2>
+      <h2>Temperature Service</h2>
       <div className="control-row">
         <button
           onClick={() => setListening(!listening)}
@@ -298,7 +298,7 @@ const ButtonsSection = ({ connection }: { connection: ServiceConnection }) => {
 
   return (
     <div className="section">
-      <h2>Buttons</h2>
+      <h2>Button Service</h2>
       <div className="control-row">
         <button
           onClick={() => setListening(!listening)}

--- a/apps/demo/src/components/UartTab.tsx
+++ b/apps/demo/src/components/UartTab.tsx
@@ -106,6 +106,7 @@ const UartTab = () => {
 
   return (
     <div className="tab-page">
+      <p className="service-note">Requires: UART Service</p>
       <ReceiveSection connection={connection} />
       <WriteSection connection={connection} />
     </div>

--- a/packages/microbit-connection/src/bluetooth/connection.ts
+++ b/packages/microbit-connection/src/bluetooth/connection.ts
@@ -7,12 +7,6 @@ import { BleClient, BleDevice } from "@capacitor-community/bluetooth-le";
 import { Capacitor } from "@capacitor/core";
 import MemoryMap from "nrf-intel-hex";
 import {
-  BluetoothDeviceWrapper,
-  isAndroid,
-  scanningTimeoutInMs,
-} from "./device-wrapper.js";
-import { profile } from "./profile.js";
-import {
   BackgroundErrorData,
   BoardVersion,
   ConnectOptions,
@@ -23,39 +17,48 @@ import {
   DeviceConnectionEventMap,
   DeviceError,
   FlashDataError,
-  assertConnected,
   FlashDataSource,
   FlashOptions,
   ProgressCallback,
   ProgressStage,
+  assertConnected,
 } from "../device.js";
 import { TypedEventTarget } from "../events.js";
-import { Logging, ConsoleLogging } from "../logging.js";
-import { fullFlash } from "./flashing/flashing-full.js";
-import partialFlash, {
-  PartialFlashResult,
-} from "./flashing/flashing-partial.js";
+import { ConsoleLogging, Logging } from "../logging.js";
 import {
   AccelerometerData,
+  ButtonActionData,
   ButtonData,
-  PinValue,
-  PinData,
+  GestureData,
   LedMatrix,
   MagnetometerData,
+  MicrobitEventData,
+  PinData,
+  PinValue,
   ServiceConnectionEventMap,
   TemperatureData,
   TypedServiceEvent,
   UartData,
 } from "../service-events.js";
+import {
+  BluetoothDeviceWrapper,
+  isAndroid,
+  scanningTimeoutInMs,
+} from "./device-wrapper.js";
+import { fullFlash } from "./flashing/flashing-full.js";
+import partialFlash, {
+  PartialFlashResult,
+} from "./flashing/flashing-partial.js";
+import { profile } from "./profile.js";
 
+import { TimeoutError } from "../async-util.js";
 import { throwIfUnavailable } from "../availability.js";
 import { truncateHexAfterEof } from "../hex-util.js";
+import { withBleErrorMapping } from "./ble-error.js";
 import {
   DefaultDeviceBondState,
   DeviceBondState,
 } from "./device-bond-state.js";
-import { TimeoutError } from "../async-util.js";
-import { withBleErrorMapping } from "./ble-error.js";
 
 type BleClientError = { message: string; errorMessage: string };
 
@@ -66,6 +69,57 @@ export interface MicrobitBluetoothConnectionOptions {
   deviceBondState?: DeviceBondState;
 }
 
+/**
+ * A Bluetooth connection to a micro:bit device.
+ *
+ * Events and methods rely on specific BLE services being present in the
+ * micro:bit's firmware. Which services are available depends on the firmware
+ * build for C++ and for a MakeCode program depends on the service blocks added
+ * from the Bluetooth extension.
+ *
+ * The table below maps each event and method to the BLE service it requires.
+ * If a service is not present, the event will silently not fire (no error is
+ * raised) and methods that depend on it will throw.
+ *
+ * ### Accelerometer Service
+ * - `accelerometerdatachanged` event
+ * - {@link getAccelerometerData}, {@link getAccelerometerPeriod}, {@link setAccelerometerPeriod}
+ *
+ * ### Button Service
+ * - `buttonachanged`, `buttonbchanged` events
+ *
+ * ### Event Service
+ * - `gesturechanged` event — also requires the accelerometer hardware to be
+ *   active; this happens automatically if the Accelerometer Service is present
+ * - `buttonaaction`, `buttonbaction`, `buttonabaction` events
+ * - `logoaction` event (V2 only)
+ * - `microbitevent` event
+ * - {@link subscribeToEvent}, {@link sendEvent}
+ *
+ * ### IO Pin Service
+ * - `pinchanged` event
+ * - {@link getAnalogPins}, {@link setAnalogPins}
+ * - {@link getInputPins}, {@link setInputPins}
+ * - {@link readPins}, {@link writePins}, {@link writePinPwm}
+ *
+ * ### LED Service
+ * - {@link setLedText}, {@link getLedScrollingDelay}, {@link setLedScrollingDelay}
+ * - {@link getLedMatrix}, {@link setLedMatrix}
+ *
+ * ### Magnetometer Service
+ * - `magnetometerdatachanged` event
+ * - {@link getMagnetometerData}, {@link getMagnetometerBearing}
+ * - {@link getMagnetometerPeriod}, {@link setMagnetometerPeriod}
+ * - {@link triggerMagnetometerCalibration}
+ *
+ * ### Temperature Service
+ * - `temperaturechanged` event
+ * - {@link getTemperature}, {@link getTemperaturePeriod}, {@link setTemperaturePeriod}
+ *
+ * ### UART Service
+ * - `uartdata` event
+ * - {@link uartWrite}
+ */
 export interface MicrobitBluetoothConnection extends DeviceConnection {
   readonly type: "bluetooth";
   // -- DeviceConnectionEventMap overloads (redeclared from base) --
@@ -81,23 +135,54 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   addEventListener(type: "afterrequestdevice", listener: () => void): void;
   addEventListener(type: "flash", listener: () => void): void;
   // -- ServiceConnectionEventMap overloads --
+  /** Requires: Accelerometer Service. */
   addEventListener(
     type: "accelerometerdatachanged",
     listener: (data: AccelerometerData) => void,
   ): void;
+  /** Requires: Button Service. */
   addEventListener(
     type: "buttonachanged" | "buttonbchanged",
     listener: (data: ButtonData) => void,
   ): void;
+  /** Requires: Magnetometer Service. */
   addEventListener(
     type: "magnetometerdatachanged",
     listener: (data: MagnetometerData) => void,
   ): void;
+  /** Requires: Temperature Service. */
   addEventListener(
     type: "temperaturechanged",
     listener: (data: TemperatureData) => void,
   ): void;
+  /** Requires: IO Pin Service. */
   addEventListener(type: "pinchanged", listener: (data: PinData) => void): void;
+  /** Requires: Event Service. The accelerometer hardware must also be active (automatic if the Accelerometer Service is present). */
+  addEventListener(
+    type: "gesturechanged",
+    listener: (data: GestureData) => void,
+  ): void;
+  /** Requires: Event Service. */
+  addEventListener(
+    type: "buttonaaction" | "buttonbaction" | "buttonabaction",
+    listener: (data: ButtonActionData) => void,
+  ): void;
+  /** Requires: Event Service. V2 only. */
+  addEventListener(
+    type: "logoaction",
+    listener: (data: ButtonActionData) => void,
+  ): void;
+  /**
+   * Requires: Event Service. Receives raw micro:bit message bus events
+   * registered via {@link subscribeToEvent}. Higher-level events supported
+   * by the event service, like `gesturechanged` and button actions, are not
+   * included here unless you subscribe to them using {@link subscribeToEvent}.
+   */
+  addEventListener(
+    type: "microbitevent",
+    listener: (data: MicrobitEventData) => void,
+  ): void;
+  /** Requires: UART Service. */
   addEventListener(type: "uartdata", listener: (data: UartData) => void): void;
 
   removeEventListener(
@@ -132,6 +217,22 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
     listener: (data: PinData) => void,
   ): void;
   removeEventListener(
+    type: "gesturechanged",
+    listener: (data: GestureData) => void,
+  ): void;
+  removeEventListener(
+    type: "buttonaaction" | "buttonbaction" | "buttonabaction",
+    listener: (data: ButtonActionData) => void,
+  ): void;
+  removeEventListener(
+    type: "logoaction",
+    listener: (data: ButtonActionData) => void,
+  ): void;
+  removeEventListener(
+    type: "microbitevent",
+    listener: (data: MicrobitEventData) => void,
+  ): void;
+  removeEventListener(
     type: "uartdata",
     listener: (data: UartData) => void,
   ): void;
@@ -146,6 +247,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Gets micro:bit accelerometer data.
    *
+   * Requires: Accelerometer Service.
+   *
    * @returns accelerometer data.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -153,6 +256,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
 
   /**
    * Gets micro:bit accelerometer period.
+   *
+   * Requires: Accelerometer Service.
    *
    * @returns accelerometer period.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -162,6 +267,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Sets micro:bit accelerometer period.
    *
+   * Requires: Accelerometer Service.
+   *
    * @param value The accelerometer period.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -169,6 +276,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
 
   /**
    * Sets micro:bit LED text.
+   *
+   * Requires: LED Service.
    *
    * @param text The text displayed on micro:bit LED.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -178,6 +287,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Gets micro:bit LED scrolling delay.
    *
+   * Requires: LED Service.
+   *
    * @returns LED scrolling delay in milliseconds.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -185,6 +296,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
 
   /**
    * Sets micro:bit LED scrolling delay.
+   *
+   * Requires: LED Service.
    *
    * @param delayInMillis LED scrolling delay in milliseconds.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -194,6 +307,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Gets micro:bit LED matrix.
    *
+   * Requires: LED Service.
+   *
    * @returns a boolean matrix representing the micro:bit LED display.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -201,6 +316,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
 
   /**
    * Sets micro:bit LED matrix.
+   *
+   * Requires: LED Service.
    *
    * @param matrix an boolean matrix representing the micro:bit LED display.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -210,6 +327,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Gets micro:bit magnetometer data.
    *
+   * Requires: Magnetometer Service.
+   *
    * @returns magnetometer data.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -217,6 +336,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
 
   /**
    * Gets micro:bit magnetometer bearing.
+   *
+   * Requires: Magnetometer Service.
    *
    * @returns magnetometer bearing.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -226,6 +347,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Gets micro:bit magnetometer period.
    *
+   * Requires: Magnetometer Service.
+   *
    * @returns magnetometer period.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -233,6 +356,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
 
   /**
    * Sets micro:bit magnetometer period.
+   *
+   * Requires: Magnetometer Service.
    *
    * @param value magnetometer period.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -242,12 +367,16 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Triggers micro:bit magnetometer calibration.
    *
+   * Requires: Magnetometer Service.
+   *
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
   triggerMagnetometerCalibration(): Promise<void>;
 
   /**
    * Gets the micro:bit temperature in degrees Celsius.
+   *
+   * Requires: Temperature Service.
    *
    * @returns temperature in degrees Celsius.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -257,6 +386,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Gets the micro:bit temperature sensor period.
    *
+   * Requires: Temperature Service.
+   *
    * @returns temperature period in milliseconds.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -264,6 +395,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
 
   /**
    * Sets the micro:bit temperature sensor period.
+   *
+   * Requires: Temperature Service.
    *
    * @param value period in milliseconds.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -274,6 +407,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
    * Gets which pins are configured as analog.
    * All other pins are digital (the default).
    *
+   * Requires: IO Pin Service.
+   *
    * @returns array of pin numbers (0-18) configured as analog.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -282,6 +417,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Sets which pins are configured as analog.
    * All other pins become digital (the default).
+   *
+   * Requires: IO Pin Service.
    *
    * @param pins array of pin numbers (0-18) to configure as analog.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -292,6 +429,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
    * Gets which pins are configured as inputs.
    * Input pins are monitored and their values reported via notifications.
    * All other pins are outputs (the default).
+   *
+   * Requires: IO Pin Service.
    *
    * @returns array of pin numbers (0-18) configured as inputs.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -307,6 +446,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
    * (e.g. touch sensing used by MakeCode "on pin pressed" blocks).
    * The two cannot be used on the same pin simultaneously.
    *
+   * Requires: IO Pin Service.
+   *
    * @param pins array of pin numbers (0-18) to configure as inputs.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -318,6 +459,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
    * pin configured as an input, up to a firmware limit of 10 pins
    * (lowest-numbered first).
    *
+   * Requires: IO Pin Service.
+   *
    * @returns array of pin/value pairs.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -326,6 +469,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   /**
    * Writes pin data for output pins.
    *
+   * Requires: IO Pin Service.
+   *
    * @param data array of pin/value pairs.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
    */
@@ -333,6 +478,8 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
 
   /**
    * Sets PWM output on a pin.
+   *
+   * Requires: IO Pin Service.
    *
    * @param pin Pin number (0-18).
    * @param options PWM configuration.
@@ -346,7 +493,37 @@ export interface MicrobitBluetoothConnection extends DeviceConnection {
   ): Promise<void>;
 
   /**
+   * Register interest in a specific micro:bit message bus event.
+   * Tells the micro:bit to forward matching message bus traffic over BLE.
+   * Matching events are dispatched as `microbitevent`.
+   * Use 0 as the value to match all events from a source.
+   *
+   * For common message bus events, consider the higher-level alternatives:
+   * `gesturechanged`, `buttonaaction`, `buttonbaction`, `buttonabaction`.
+   *
+   * Requires: Event Service.
+   *
+   * @param source Event source ID.
+   * @param value Event value to match, or 0 for any.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
+   */
+  subscribeToEvent(source: number, value: number): Promise<void>;
+
+  /**
+   * Send an event to the micro:bit's message bus.
+   *
+   * Requires: Event Service.
+   *
+   * @param source Event source ID.
+   * @param value Event value.
+   * @throws {DeviceError} with code `not-connected` if there is no connection.
+   */
+  sendEvent(source: number, value: number): Promise<void>;
+
+  /**
    * Write UART messages.
+   *
+   * Requires: UART Service.
    *
    * @param data UART message.
    * @throws {DeviceError} with code `not-connected` if there is no connection.
@@ -733,6 +910,20 @@ class MicrobitBluetoothConnectionImpl
     assertConnected(this.device);
     return withBleErrorMapping(() =>
       this.device!.ioPin.setPwm(pin, options.value, options.period),
+    );
+  }
+
+  async subscribeToEvent(source: number, value: number): Promise<void> {
+    assertConnected(this.device);
+    return withBleErrorMapping(() =>
+      this.device!.events.subscribeToEvent(source, value),
+    );
+  }
+
+  async sendEvent(source: number, value: number): Promise<void> {
+    assertConnected(this.device);
+    return withBleErrorMapping(() =>
+      this.device!.events.sendEvent(source, value),
     );
   }
 

--- a/packages/microbit-connection/src/bluetooth/device-wrapper.ts
+++ b/packages/microbit-connection/src/bluetooth/device-wrapper.ts
@@ -38,6 +38,7 @@ import {
   TypedServiceEvent,
   TypedServiceEventDispatcher,
 } from "../service-events.js";
+import { EventService } from "./services/event-service.js";
 import { TemperatureService } from "./services/temperature-service.js";
 import { IoPinService } from "./services/io-pin-service.js";
 import { UARTService } from "./services/uart-service.js";
@@ -104,6 +105,7 @@ export class BluetoothDeviceWrapper implements Logging {
   accelerometer: AccelerometerService;
   buttons: ButtonService;
   deviceInformation: DeviceInformationService;
+  events: EventService;
   ioPin: IoPinService;
   led: LedService;
   magnetometer: MagnetometerService;
@@ -137,6 +139,11 @@ export class BluetoothDeviceWrapper implements Logging {
     );
     this.buttons = new ButtonService(bleDevice.deviceId, dispatchTypedEvent);
     this.deviceInformation = new DeviceInformationService(bleDevice.deviceId);
+    this.events = new EventService(
+      bleDevice.deviceId,
+      dispatchTypedEvent,
+      () => this.boardVersion,
+    );
     this.ioPin = new IoPinService(bleDevice.deviceId, dispatchTypedEvent);
     this.led = new LedService(bleDevice.deviceId);
     this.magnetometer = new MagnetometerService(
@@ -151,6 +158,7 @@ export class BluetoothDeviceWrapper implements Logging {
     this.services = [
       this.accelerometer,
       this.buttons,
+      this.events,
       this.ioPin,
       this.led,
       this.magnetometer,

--- a/packages/microbit-connection/src/bluetooth/services/event-service.test.ts
+++ b/packages/microbit-connection/src/bluetooth/services/event-service.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { BleClient } from "@capacitor-community/bluetooth-le";
+import { EventService } from "./event-service.js";
+import { V2Source, GestureEvent, ButtonAction } from "../../microbit-events.js";
+import type { TypedServiceEventDispatcher } from "../../service-events.js";
+
+vi.mock("@capacitor-community/bluetooth-le", () => ({
+  BleClient: {
+    startNotifications: vi.fn().mockResolvedValue(undefined),
+    stopNotifications: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn().mockResolvedValue(undefined),
+    writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../ble-error.js", () => ({
+  mapBleError: (e: unknown) => e,
+}));
+
+function makeEvent(source: number, value: number): DataView {
+  const data = new DataView(new ArrayBuffer(4));
+  data.setUint16(0, source, true);
+  data.setUint16(2, value, true);
+  return data;
+}
+
+function makeMultiEvent(...pairs: [number, number][]): DataView {
+  const data = new DataView(new ArrayBuffer(pairs.length * 4));
+  pairs.forEach(([source, value], i) => {
+    data.setUint16(i * 4, source, true);
+    data.setUint16(i * 4 + 2, value, true);
+  });
+  return data;
+}
+
+/** Captures the notification callback passed to BleClient.startNotifications */
+function captureNotificationCallback(): (data: DataView) => void {
+  const calls = (BleClient.startNotifications as Mock).mock.calls;
+  const lastCall = calls[calls.length - 1];
+  return lastCall[3];
+}
+
+describe("EventService", () => {
+  let service: EventService;
+  let dispatch: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatch = vi.fn();
+    service = new EventService(
+      "test-device",
+      dispatch as TypedServiceEventDispatcher,
+      () => "V2",
+    );
+  });
+
+  describe("named events", () => {
+    it("dispatches gesturechanged when listening", async () => {
+      await service.startNotifications("gesturechanged");
+      const notify = captureNotificationCallback();
+
+      notify(makeEvent(V2Source.Gesture, GestureEvent.Shake));
+
+      expect(dispatch).toHaveBeenCalledWith("gesturechanged", {
+        gesture: GestureEvent.Shake,
+      });
+    });
+
+    it("dispatches button actions for A, B, AB", async () => {
+      await service.startNotifications("buttonaaction");
+      await service.startNotifications("buttonbaction");
+      await service.startNotifications("buttonabaction");
+      const notify = captureNotificationCallback();
+
+      notify(makeEvent(V2Source.ButtonA, ButtonAction.Click));
+      notify(makeEvent(V2Source.ButtonB, ButtonAction.LongClick));
+      notify(makeEvent(V2Source.ButtonAB, ButtonAction.DoubleClick));
+
+      expect(dispatch).toHaveBeenCalledWith("buttonaaction", {
+        button: "A",
+        action: ButtonAction.Click,
+      });
+      expect(dispatch).toHaveBeenCalledWith("buttonbaction", {
+        button: "B",
+        action: ButtonAction.LongClick,
+      });
+      expect(dispatch).toHaveBeenCalledWith("buttonabaction", {
+        button: "AB",
+        action: ButtonAction.DoubleClick,
+      });
+    });
+
+    it("dispatches logoaction (V2 only)", async () => {
+      await service.startNotifications("logoaction");
+      const notify = captureNotificationCallback();
+
+      notify(makeEvent(V2Source.Logo, ButtonAction.Click));
+
+      expect(dispatch).toHaveBeenCalledWith("logoaction", {
+        button: "Logo",
+        action: ButtonAction.Click,
+      });
+    });
+
+    it("does not dispatch after stopping a named event", async () => {
+      await service.startNotifications("gesturechanged");
+      const notify = captureNotificationCallback();
+      await service.stopNotifications("gesturechanged");
+
+      notify(makeEvent(V2Source.Gesture, GestureEvent.Shake));
+
+      expect(dispatch).not.toHaveBeenCalledWith(
+        "gesturechanged",
+        expect.anything(),
+      );
+    });
+
+    it("handles multiple events packed in one notification", async () => {
+      await service.startNotifications("gesturechanged");
+      await service.startNotifications("buttonaaction");
+      const notify = captureNotificationCallback();
+
+      notify(
+        makeMultiEvent(
+          [V2Source.Gesture, GestureEvent.FaceUp],
+          [V2Source.ButtonA, ButtonAction.Click],
+        ),
+      );
+
+      expect(dispatch).toHaveBeenCalledWith("gesturechanged", {
+        gesture: GestureEvent.FaceUp,
+      });
+      expect(dispatch).toHaveBeenCalledWith("buttonaaction", {
+        button: "A",
+        action: ButtonAction.Click,
+      });
+    });
+  });
+
+  describe("microbitevent isolation", () => {
+    it("does not dispatch microbitevent for named event traffic", async () => {
+      await service.startNotifications("gesturechanged");
+      await service.startNotifications("microbitevent");
+      const notify = captureNotificationCallback();
+
+      notify(makeEvent(V2Source.Gesture, GestureEvent.Shake));
+
+      expect(dispatch).toHaveBeenCalledWith("gesturechanged", {
+        gesture: GestureEvent.Shake,
+      });
+      expect(dispatch).not.toHaveBeenCalledWith(
+        "microbitevent",
+        expect.anything(),
+      );
+    });
+
+    it("dispatches microbitevent only for explicit subscriptions", async () => {
+      await service.startNotifications("microbitevent");
+      await service.subscribeToEvent(999, 0);
+      const notify = captureNotificationCallback();
+
+      notify(makeEvent(999, 42));
+
+      expect(dispatch).toHaveBeenCalledWith("microbitevent", {
+        source: 999,
+        value: 42,
+      });
+    });
+
+    it("wildcard subscription (value=0) matches all values from that source", async () => {
+      await service.startNotifications("microbitevent");
+      await service.subscribeToEvent(999, 0);
+      const notify = captureNotificationCallback();
+
+      notify(makeEvent(999, 1));
+      notify(makeEvent(999, 2));
+      notify(makeEvent(888, 1));
+
+      expect(dispatch).toHaveBeenCalledWith("microbitevent", {
+        source: 999,
+        value: 1,
+      });
+      expect(dispatch).toHaveBeenCalledWith("microbitevent", {
+        source: 999,
+        value: 2,
+      });
+      expect(dispatch).not.toHaveBeenCalledWith(
+        "microbitevent",
+        expect.objectContaining({ source: 888 }),
+      );
+    });
+
+    it("exact subscription only matches that specific value", async () => {
+      await service.startNotifications("microbitevent");
+      await service.subscribeToEvent(999, 5);
+      const notify = captureNotificationCallback();
+
+      notify(makeEvent(999, 5));
+      notify(makeEvent(999, 6));
+
+      expect(dispatch).toHaveBeenCalledWith("microbitevent", {
+        source: 999,
+        value: 5,
+      });
+      expect(dispatch).not.toHaveBeenCalledWith(
+        "microbitevent",
+        expect.objectContaining({ value: 6 }),
+      );
+    });
+
+    it("named events and explicit subscriptions work independently", async () => {
+      await service.startNotifications("gesturechanged");
+      await service.startNotifications("microbitevent");
+      await service.subscribeToEvent(999, 0);
+      const notify = captureNotificationCallback();
+
+      // Gesture events go to gesturechanged only
+      notify(makeEvent(V2Source.Gesture, GestureEvent.Shake));
+      // Custom events go to microbitevent only
+      notify(makeEvent(999, 42));
+
+      expect(dispatch).toHaveBeenCalledWith("gesturechanged", {
+        gesture: GestureEvent.Shake,
+      });
+      expect(dispatch).toHaveBeenCalledWith("microbitevent", {
+        source: 999,
+        value: 42,
+      });
+      // Gesture should NOT leak into microbitevent
+      expect(dispatch).not.toHaveBeenCalledWith(
+        "microbitevent",
+        expect.objectContaining({ source: V2Source.Gesture }),
+      );
+    });
+
+    it("overlapping named + explicit subscription dispatches both", async () => {
+      await service.startNotifications("gesturechanged");
+      await service.startNotifications("microbitevent");
+      // Explicitly subscribe to the same source as the named event
+      await service.subscribeToEvent(V2Source.Gesture, 0);
+      const notify = captureNotificationCallback();
+
+      notify(makeEvent(V2Source.Gesture, GestureEvent.Shake));
+
+      // Both fire — you asked for both
+      expect(dispatch).toHaveBeenCalledWith("gesturechanged", {
+        gesture: GestureEvent.Shake,
+      });
+      expect(dispatch).toHaveBeenCalledWith("microbitevent", {
+        source: V2Source.Gesture,
+        value: GestureEvent.Shake,
+      });
+    });
+
+    it("stopping named event leaves explicit subscription working", async () => {
+      await service.startNotifications("gesturechanged");
+      await service.startNotifications("microbitevent");
+      await service.subscribeToEvent(V2Source.Gesture, 0);
+      const notify = captureNotificationCallback();
+
+      await service.stopNotifications("gesturechanged");
+      dispatch.mockClear();
+
+      notify(makeEvent(V2Source.Gesture, GestureEvent.Shake));
+
+      // Named event stopped
+      expect(dispatch).not.toHaveBeenCalledWith(
+        "gesturechanged",
+        expect.anything(),
+      );
+      // Explicit subscription still works
+      expect(dispatch).toHaveBeenCalledWith("microbitevent", {
+        source: V2Source.Gesture,
+        value: GestureEvent.Shake,
+      });
+    });
+  });
+
+  describe("BLE notification lifecycle", () => {
+    it("re-registers BLE notifications on each startNotifications call to handle reconnect", async () => {
+      await service.startNotifications("gesturechanged");
+      await service.startNotifications("buttonaaction");
+      await service.startNotifications("microbitevent");
+
+      expect(BleClient.startNotifications).toHaveBeenCalledTimes(3);
+    });
+
+    it("stops BLE notifications only when all event types are stopped", async () => {
+      await service.startNotifications("gesturechanged");
+      await service.startNotifications("buttonaaction");
+
+      await service.stopNotifications("gesturechanged");
+      expect(BleClient.stopNotifications).not.toHaveBeenCalled();
+
+      await service.stopNotifications("buttonaaction");
+      expect(BleClient.stopNotifications).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores irrelevant event types", async () => {
+      await service.startNotifications("accelerometerdatachanged");
+      expect(BleClient.startNotifications).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("client requirements", () => {
+    it("writes client requirements for named events", async () => {
+      await service.startNotifications("gesturechanged");
+
+      expect(BleClient.write).toHaveBeenCalled();
+      const calls = (BleClient.write as Mock).mock.calls;
+      const data = calls[calls.length - 1][3] as DataView;
+      expect(data.getUint16(0, true)).toBe(V2Source.Gesture);
+      expect(data.getUint16(2, true)).toBe(0);
+    });
+
+    it("writes client requirements for explicit subscriptions", async () => {
+      await service.subscribeToEvent(999, 42);
+
+      expect(BleClient.write).toHaveBeenCalled();
+      const calls = (BleClient.write as Mock).mock.calls;
+      const data = calls[calls.length - 1][3] as DataView;
+      expect(data.getUint16(0, true)).toBe(999);
+      expect(data.getUint16(2, true)).toBe(42);
+    });
+
+    it("does not duplicate explicit subscription writes", async () => {
+      await service.subscribeToEvent(999, 42);
+      await service.subscribeToEvent(999, 42);
+
+      expect(BleClient.write).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/microbit-connection/src/bluetooth/services/event-service.ts
+++ b/packages/microbit-connection/src/bluetooth/services/event-service.ts
@@ -1,0 +1,290 @@
+import { BleClient } from "@capacitor-community/bluetooth-le";
+import { Service } from "../device-wrapper.js";
+import {
+  TypedServiceEvent,
+  TypedServiceEventDispatcher,
+} from "../../service-events.js";
+import { profile } from "../profile.js";
+import { mapBleError } from "../ble-error.js";
+import { BoardVersion } from "../../device.js";
+import {
+  EventSource,
+  V2Source,
+  type GestureEvent,
+  type ButtonAction,
+} from "../../microbit-events.js";
+
+type VersionSource = (typeof EventSource)["v1"] | (typeof EventSource)["v2"];
+
+const NAMED_EVENTS = [
+  "gesturechanged",
+  "buttonaaction",
+  "buttonbaction",
+  "buttonabaction",
+  "logoaction",
+] as const;
+
+type NamedEvent = (typeof NAMED_EVENTS)[number];
+
+function isNamedEvent(type: string): type is NamedEvent {
+  return (NAMED_EVENTS as readonly string[]).includes(type);
+}
+
+export class EventService implements Service {
+  uuid = profile.event.id;
+
+  private activeEventTypes = new Set<string>();
+  /**
+   * Filters registered via named events (gestures, buttons), keyed as "source:value".
+   * Persists across reconnects so we can replay them.
+   */
+  private namedRequirements = new Set<string>();
+  /**
+   * Filters registered via explicit {@link subscribeToEvent} calls, keyed as "source:value".
+   * Only events matching these are dispatched as `microbitevent`.
+   * Persists across reconnects so we can replay them.
+   */
+  private explicitSubscriptions = new Set<string>();
+  /**
+   * Tracks which named event types contributed which filter keys,
+   * so we can clean up when a named event is stopped.
+   */
+  private namedEventFilters = new Map<string, string[]>();
+
+  constructor(
+    private deviceId: string,
+    private dispatchTypedEvent: TypedServiceEventDispatcher,
+    private getBoardVersion: () => BoardVersion | undefined,
+  ) {}
+
+  getRelevantEvents(): TypedServiceEvent[] {
+    return [
+      "gesturechanged",
+      "buttonaaction",
+      "buttonbaction",
+      "buttonabaction",
+      "logoaction",
+      "microbitevent",
+    ];
+  }
+
+  async startNotifications(type: TypedServiceEvent): Promise<void> {
+    if (!this.getRelevantEvents().includes(type)) {
+      return;
+    }
+    this.activeEventTypes.add(type);
+
+    try {
+      // Always (re-)register the BLE notification. After a reconnect the
+      // previous subscription is gone even though the service instance is
+      // reused, so we cannot skip this.
+      await BleClient.startNotifications(
+        this.deviceId,
+        profile.event.id,
+        profile.event.characteristics.microBitEvent.id,
+        (value) => this.handleNotification(value),
+      );
+
+      if (isNamedEvent(type)) {
+        this.writeRequirementsForNamedEvent(type);
+      }
+
+      // Replay all filters (handles reconnect case where the micro:bit
+      // has lost its listener registrations).
+      await this.replayAllRequirements();
+    } catch (e) {
+      this.dispatchTypedEvent("backgrounderror", {
+        error: mapBleError(e),
+        event: type,
+      });
+    }
+  }
+
+  async stopNotifications(type: TypedServiceEvent): Promise<void> {
+    if (!this.getRelevantEvents().includes(type)) {
+      return;
+    }
+    this.activeEventTypes.delete(type);
+
+    // Remove filters contributed by this named event type
+    if (isNamedEvent(type)) {
+      const keys = this.namedEventFilters.get(type) ?? [];
+      for (const key of keys) {
+        this.namedRequirements.delete(key);
+      }
+      this.namedEventFilters.delete(type);
+    }
+
+    if (this.activeEventTypes.size === 0) {
+      try {
+        await BleClient.stopNotifications(
+          this.deviceId,
+          profile.event.id,
+          profile.event.characteristics.microBitEvent.id,
+        );
+      } catch (e) {
+        this.dispatchTypedEvent("backgrounderror", {
+          error: mapBleError(e),
+          event: type,
+        });
+      }
+    }
+  }
+
+  /**
+   * Register interest in a specific micro:bit message bus event.
+   * Tells the micro:bit to forward matching message bus traffic over BLE.
+   * Matching events are dispatched as `microbitevent`.
+   * Use 0 as the value to match all events from a source.
+   */
+  async subscribeToEvent(source: number, value: number): Promise<void> {
+    const key = filterKey(source, value);
+    if (!this.explicitSubscriptions.has(key)) {
+      this.explicitSubscriptions.add(key);
+      await this.writeClientRequirement(source, value);
+    }
+  }
+
+  /**
+   * Send an event to the micro:bit's message bus.
+   */
+  async sendEvent(source: number, value: number): Promise<void> {
+    const data = new DataView(new ArrayBuffer(4));
+    data.setUint16(0, source, true);
+    data.setUint16(2, value, true);
+    await BleClient.writeWithoutResponse(
+      this.deviceId,
+      profile.event.id,
+      profile.event.characteristics.clientEvent.id,
+      data,
+    );
+  }
+
+  private handleNotification(dataView: DataView): void {
+    for (let offset = 0; offset + 4 <= dataView.byteLength; offset += 4) {
+      const source = dataView.getUint16(offset, true);
+      const value = dataView.getUint16(offset + 2, true);
+
+      if (
+        this.activeEventTypes.has("microbitevent") &&
+        this.matchesExplicitSubscription(source, value)
+      ) {
+        this.dispatchTypedEvent("microbitevent", { source, value });
+      }
+
+      this.demuxToNamedEvents(source, value);
+    }
+  }
+
+  private demuxToNamedEvents(source: number, value: number): void {
+    const src = this.getSourceIds();
+    if (!src) return;
+
+    if (source === src.Gesture && this.activeEventTypes.has("gesturechanged")) {
+      this.dispatchTypedEvent("gesturechanged", {
+        gesture: value as GestureEvent,
+      });
+    }
+    if (source === src.ButtonA && this.activeEventTypes.has("buttonaaction")) {
+      this.dispatchTypedEvent("buttonaaction", {
+        button: "A",
+        action: value as ButtonAction,
+      });
+    }
+    if (source === src.ButtonB && this.activeEventTypes.has("buttonbaction")) {
+      this.dispatchTypedEvent("buttonbaction", {
+        button: "B",
+        action: value as ButtonAction,
+      });
+    }
+    if (
+      source === src.ButtonAB &&
+      this.activeEventTypes.has("buttonabaction")
+    ) {
+      this.dispatchTypedEvent("buttonabaction", {
+        button: "AB",
+        action: value as ButtonAction,
+      });
+    }
+    if (source === V2Source.Logo && this.activeEventTypes.has("logoaction")) {
+      this.dispatchTypedEvent("logoaction", {
+        button: "Logo",
+        action: value as ButtonAction,
+      });
+    }
+  }
+
+  private writeRequirementsForNamedEvent(type: NamedEvent): void {
+    const src = this.getSourceIds();
+    if (!src) return;
+
+    const filters: Array<[number, number]> = [];
+    switch (type) {
+      case "gesturechanged":
+        filters.push([src.Gesture, 0]);
+        break;
+      case "buttonaaction":
+        filters.push([src.ButtonA, 0]);
+        break;
+      case "buttonbaction":
+        filters.push([src.ButtonB, 0]);
+        break;
+      case "buttonabaction":
+        filters.push([src.ButtonAB, 0]);
+        break;
+      case "logoaction":
+        filters.push([V2Source.Logo, 0]);
+        break;
+    }
+
+    const keys: string[] = [];
+    for (const [source, value] of filters) {
+      const key = filterKey(source, value);
+      keys.push(key);
+      this.namedRequirements.add(key);
+    }
+    this.namedEventFilters.set(type, keys);
+  }
+
+  private matchesExplicitSubscription(source: number, value: number): boolean {
+    if (this.explicitSubscriptions.has(filterKey(source, value))) return true;
+    if (this.explicitSubscriptions.has(filterKey(source, 0))) return true;
+    return false;
+  }
+
+  private async replayAllRequirements(): Promise<void> {
+    for (const key of this.namedRequirements) {
+      const [source, value] = key.split(":").map(Number);
+      await this.writeClientRequirement(source, value);
+    }
+    for (const key of this.explicitSubscriptions) {
+      const [source, value] = key.split(":").map(Number);
+      await this.writeClientRequirement(source, value);
+    }
+  }
+
+  private async writeClientRequirement(
+    source: number,
+    value: number,
+  ): Promise<void> {
+    const data = new DataView(new ArrayBuffer(4));
+    data.setUint16(0, source, true);
+    data.setUint16(2, value, true);
+    await BleClient.write(
+      this.deviceId,
+      profile.event.id,
+      profile.event.characteristics.clientRequirements.id,
+      data,
+    );
+  }
+
+  private getSourceIds(): VersionSource | undefined {
+    const version = this.getBoardVersion();
+    if (!version) return undefined;
+    return version === "V1" ? EventSource.v1 : EventSource.v2;
+  }
+}
+
+function filterKey(source: number, value: number): string {
+  return `${source}:${value}`;
+}

--- a/packages/microbit-connection/src/index.ts
+++ b/packages/microbit-connection/src/index.ts
@@ -21,9 +21,12 @@ import {
 import { Logging, LoggingEvent } from "./logging.js";
 import {
   AccelerometerData,
+  ButtonActionData,
   ButtonData,
-  ButtonEventType,
+  ButtonActionType,
   ButtonState,
+  GestureData,
+  MicrobitEventData,
   PinValue,
   PinData,
   LedMatrix,
@@ -31,12 +34,15 @@ import {
   TemperatureData,
   UartData,
 } from "./service-events.js";
+import { ButtonAction, GestureEvent } from "./microbit-events.js";
 
 export {
+  ButtonAction,
   ButtonState,
   ConnectionStatus,
   DeviceError,
   FlashDataError,
+  GestureEvent,
   assertConnected,
   ProgressStage,
 };
@@ -45,8 +51,9 @@ export type {
   AccelerometerData,
   BackgroundErrorData,
   BoardVersion,
+  ButtonActionData,
   ButtonData,
-  ButtonEventType,
+  ButtonActionType,
   ConnectOptions,
   ConnectionAvailabilityStatus,
   ConnectionStatusChange,
@@ -54,6 +61,8 @@ export type {
   DeviceErrorCode,
   FlashDataSource,
   FlashOptions,
+  GestureData,
+  MicrobitEventData,
   PinValue,
   PinData,
   LedMatrix,

--- a/packages/microbit-connection/src/microbit-events.ts
+++ b/packages/microbit-connection/src/microbit-events.ts
@@ -1,0 +1,58 @@
+/**
+ * Well-known micro:bit message bus event source IDs and values.
+ *
+ * Source IDs differ between V1 (DAL) and V2 (CODAL). Event values are
+ * identical across versions (V2 adds TwoG to gesture values).
+ *
+ * @see https://lancaster-university.github.io/microbit-docs/
+ */
+
+/**
+ * Event source IDs for micro:bit V1 (DAL).
+ */
+export const V1Source = {
+  ButtonA: 1,
+  ButtonB: 2,
+  ButtonAB: 26,
+  Gesture: 27,
+} as const;
+
+/**
+ * Event source IDs for micro:bit V2 (CODAL).
+ */
+export const V2Source = {
+  ButtonA: 1,
+  ButtonB: 2,
+  ButtonAB: 3,
+  Gesture: 13,
+  Logo: 121,
+} as const;
+
+export const EventSource = { v1: V1Source, v2: V2Source } as const;
+
+export const GestureEvent = {
+  TiltUp: 1,
+  TiltDown: 2,
+  TiltLeft: 3,
+  TiltRight: 4,
+  FaceUp: 5,
+  FaceDown: 6,
+  Freefall: 7,
+  Acceleration3g: 8,
+  Acceleration6g: 9,
+  Acceleration8g: 10,
+  Shake: 11,
+  /** V2 only. */
+  Acceleration2g: 12,
+} as const;
+export type GestureEvent = (typeof GestureEvent)[keyof typeof GestureEvent];
+
+export const ButtonAction = {
+  Down: 1,
+  Up: 2,
+  Click: 3,
+  LongClick: 4,
+  Hold: 5,
+  DoubleClick: 6,
+} as const;
+export type ButtonAction = (typeof ButtonAction)[keyof typeof ButtonAction];

--- a/packages/microbit-connection/src/service-events.ts
+++ b/packages/microbit-connection/src/service-events.ts
@@ -1,4 +1,5 @@
 import { DeviceConnectionEventMap } from "./device.js";
+import type { GestureEvent, ButtonAction } from "./microbit-events.js";
 
 export interface AccelerometerData {
   x: number;
@@ -14,7 +15,7 @@ export const ButtonState = {
 
 export type ButtonState = (typeof ButtonState)[keyof typeof ButtonState];
 
-export type ButtonEventType = "buttonachanged" | "buttonbchanged";
+export type ButtonActionType = "buttonachanged" | "buttonbchanged";
 
 export interface ButtonData {
   button: "A" | "B";
@@ -60,6 +61,25 @@ export interface PinData {
   data: PinValue[];
 }
 
+export interface GestureData {
+  gesture: GestureEvent;
+}
+
+export interface ButtonActionData {
+  button: "A" | "B" | "AB" | "Logo";
+  action: ButtonAction;
+}
+
+/**
+ * A raw event from the micro:bit's message bus, received via the
+ * BLE Event Service. Use {@link MicrobitBluetoothConnection.subscribeToEvent}
+ * to register which events the micro:bit should forward.
+ */
+export interface MicrobitEventData {
+  source: number;
+  value: number;
+}
+
 export interface UartData {
   value: Uint8Array;
 }
@@ -75,6 +95,12 @@ export interface ServiceConnectionEventMap {
   magnetometerdatachanged: MagnetometerData;
   temperaturechanged: TemperatureData;
   pinchanged: PinData;
+  gesturechanged: GestureData;
+  buttonaaction: ButtonActionData;
+  buttonbaction: ButtonActionData;
+  buttonabaction: ButtonActionData;
+  logoaction: ButtonActionData;
+  microbitevent: MicrobitEventData;
   uartdata: UartData;
 }
 


### PR DESCRIPTION
Pin events can be added as a high-level feature later if there's demand. They make much less sense for a general purpose "control/monitor the micro:bit over BLE" program. Though maybe useful for digital twin projects as they can observe pins without changing the pin mode (but can't read values, just transitions).

For now they're accessible via the numeric API with CODAL/DAL constants in the user program.

I do slightly wonder what the point of the button service is now...