### PR TITLE
Deploy the docs for semver stable tags only

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,7 +28,7 @@ jobs:
           path: ./packages/microbit-connection/docs/build
 
   deploy:
-    if: false
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
This will merge back to main cleanly.