### PR TITLE
Format the whole repo with prettier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,13 @@ jobs:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
           cache: npm
-      - uses: microbit-foundation/npm-package-versioner-action@v3
-        with:
-          working-directory: packages/microbit-connection
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm run format:check
+      - uses: microbit-foundation/npm-package-versioner-action@v3
+        with:
+          working-directory: packages/microbit-connection
       - run: npm run ci
       - run: npm publish -w @microbit/microbit-connection
         if: github.event_name == 'release' && github.event.action == 'created'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+node_modules
+
+# Build / dist output
+build
+dist
+docs/build
+
+# Capacitor native projects (have their own tooling)
+apps/*/android
+apps/*/ios
+
+# Generated / vendored binaries and lockfiles
+apps/*/public/hex-files
+hex-files
+packages/microbit-connection/examples
+package-lock.json
+*.hex

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,9 @@
 - Figure out the interface for flash
-    - Remove the sim? It's unrelated really.
-    - Add a JS partial flashing implementation, perhaps based on the prototype app
-    - Consider a full flash implementation later... for now we'll need to indicate lack of support somehow with a structured error code?
+  - Remove the sim? It's unrelated really.
+  - Add a JS partial flashing implementation, perhaps based on the prototype app
+  - Consider a full flash implementation later... for now we'll need to indicate lack of support somehow with a structured error code?
 
 Doc links for the memory map:
+
 - https://microbit-micropython.readthedocs.io/en/v2-docs/devguide/hexformat.html
 - https://github.com/lancaster-university/codal-microbit-v2/blob/master/docs/MemoryMap.md

--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -1,9 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>micro:bit connection demo</title>
   </head>
   <body>

--- a/apps/demo/src/App.css
+++ b/apps/demo/src/App.css
@@ -7,7 +7,9 @@
   background: #f5f5f5;
   color: #333;
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
   white-space: nowrap;
 }
 
@@ -264,7 +266,9 @@
   color: #666;
   cursor: pointer;
   white-space: nowrap;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
 
 .tab-btn:hover {
@@ -332,7 +336,9 @@
 
 /* Flash overlay dialog */
 .flash-dialog {
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2), 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.2),
+    0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .flash-dialog h2 {
@@ -472,7 +478,9 @@
   border: 2px solid #ccc;
   border-radius: 4px;
   cursor: pointer;
-  transition: background 0.1s, border-color 0.1s;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
 }
 
 .pattern-cell.lit {

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -24,7 +24,11 @@ type Tab = "flash" | "sensors" | "io" | "pins" | "events" | "serial" | "uart";
 
 const tabDefs: { id: Tab; label: string; availableFor: string[] }[] = [
   { id: "flash", label: "Flash", availableFor: ["usb", "bluetooth"] },
-  { id: "sensors", label: "Sensors", availableFor: ["bluetooth", "radio-bridge"] },
+  {
+    id: "sensors",
+    label: "Sensors",
+    availableFor: ["bluetooth", "radio-bridge"],
+  },
   { id: "io", label: "LEDs", availableFor: ["bluetooth"] },
   { id: "pins", label: "Pins", availableFor: ["bluetooth"] },
   { id: "events", label: "Events", availableFor: ["bluetooth"] },

--- a/apps/demo/src/components/ConnectionHeader.tsx
+++ b/apps/demo/src/components/ConnectionHeader.tsx
@@ -33,13 +33,14 @@ const ConnectionHeader = () => {
   const { showError } = useErrorDialog();
   const isNative = Capacitor.isNativePlatform();
 
-  const connectionOptions: { value: AnyConnection["type"]; label: string }[] = isNative
-    ? [{ value: "bluetooth", label: "Bluetooth" }]
-    : [
-        { value: "usb", label: "WebUSB" },
-        { value: "bluetooth", label: "Web Bluetooth" },
-        { value: "radio-bridge", label: "Radio Bridge" },
-      ];
+  const connectionOptions: { value: AnyConnection["type"]; label: string }[] =
+    isNative
+      ? [{ value: "bluetooth", label: "Bluetooth" }]
+      : [
+          { value: "usb", label: "WebUSB" },
+          { value: "bluetooth", label: "Web Bluetooth" },
+          { value: "radio-bridge", label: "Radio Bridge" },
+        ];
 
   return (
     <header className="app-header">
@@ -93,20 +94,29 @@ const ConnectionHeader = () => {
         Clear device
       </button>
 
-      <div className="status-indicator" role="status" aria-label="Connection status">
+      <div
+        className="status-indicator"
+        role="status"
+        aria-label="Connection status"
+      >
         <span
           className="status-dot"
           style={{ background: statusDot[status] ?? "#999" }}
           aria-hidden="true"
         />
         <span>{statusLabel[status] ?? status}</span>
-        {boardVersion && (
-          <span className="version-badge">{boardVersion}</span>
-        )}
+        {boardVersion && <span className="version-badge">{boardVersion}</span>}
       </div>
 
       {connection.type === "bluetooth" && isNative && (
-        <label style={{ fontSize: 12, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 12,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           Bond:
           <select
             value={bondMode}
@@ -122,7 +132,14 @@ const ConnectionHeader = () => {
       )}
 
       {(connection.type === "usb" || connection.type === "radio-bridge") && (
-        <label style={{ fontSize: 12, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 12,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           <input
             type="checkbox"
             checked={pauseOnHidden}
@@ -131,7 +148,6 @@ const ConnectionHeader = () => {
           Pause on hidden
         </label>
       )}
-
     </header>
   );
 };

--- a/apps/demo/src/components/ErrorDialog.tsx
+++ b/apps/demo/src/components/ErrorDialog.tsx
@@ -12,7 +12,14 @@ const ErrorDialog = () => {
       titleStyle={{ color: "#dc2626" }}
     >
       {error.code && (
-        <p style={{ fontFamily: "monospace", fontSize: 13, color: "#666", margin: "0 0 8px" }}>
+        <p
+          style={{
+            fontFamily: "monospace",
+            fontSize: 13,
+            color: "#666",
+            margin: "0 0 8px",
+          }}
+        >
           {error.code}
         </p>
       )}

--- a/apps/demo/src/components/EventsTab.tsx
+++ b/apps/demo/src/components/EventsTab.tsx
@@ -134,19 +134,27 @@ const ButtonClicksSection = ({
       <div className="sensor-readout" style={{ marginTop: 8 }}>
         <span className="axis">
           <span className="axis-label">A:</span>
-          <span className="axis-value" style={{ minWidth: 80 }}>{lastA}</span>
+          <span className="axis-value" style={{ minWidth: 80 }}>
+            {lastA}
+          </span>
         </span>
         <span className="axis">
           <span className="axis-label">B:</span>
-          <span className="axis-value" style={{ minWidth: 80 }}>{lastB}</span>
+          <span className="axis-value" style={{ minWidth: 80 }}>
+            {lastB}
+          </span>
         </span>
         <span className="axis">
           <span className="axis-label">A+B:</span>
-          <span className="axis-value" style={{ minWidth: 80 }}>{lastAB}</span>
+          <span className="axis-value" style={{ minWidth: 80 }}>
+            {lastAB}
+          </span>
         </span>
         <span className="axis">
           <span className="axis-label">Logo:</span>
-          <span className="axis-value" style={{ minWidth: 80 }}>{lastLogo}</span>
+          <span className="axis-value" style={{ minWidth: 80 }}>
+            {lastLogo}
+          </span>
         </span>
       </div>
     </div>
@@ -209,7 +217,14 @@ const RawEventsSection = ({
         </button>
       </div>
       <div className="control-row" style={{ marginTop: 8 }}>
-        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           Source:
           <input
             type="number"
@@ -219,7 +234,14 @@ const RawEventsSection = ({
             style={{ width: 60 }}
           />
         </label>
-        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           Value:
           <input
             type="number"
@@ -230,8 +252,12 @@ const RawEventsSection = ({
             placeholder="0 = any"
           />
         </label>
-        <button onClick={subscribe} className="btn">Subscribe</button>
-        <button onClick={() => setEntries([])} className="btn">Clear</button>
+        <button onClick={subscribe} className="btn">
+          Subscribe
+        </button>
+        <button onClick={() => setEntries([])} className="btn">
+          Clear
+        </button>
       </div>
       <div ref={logRef} className="data-box">
         {entries.length > 0
@@ -269,7 +295,14 @@ const SendEventSection = ({
     <div className="section">
       <h2>Send Event</h2>
       <div className="control-row">
-        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           Source:
           <input
             type="number"
@@ -279,7 +312,14 @@ const SendEventSection = ({
             style={{ width: 60 }}
           />
         </label>
-        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           Value:
           <input
             type="number"
@@ -289,7 +329,9 @@ const SendEventSection = ({
             style={{ width: 60 }}
           />
         </label>
-        <button onClick={send} className="btn">Send</button>
+        <button onClick={send} className="btn">
+          Send
+        </button>
       </div>
     </div>
   );

--- a/apps/demo/src/components/FlashOverlay.tsx
+++ b/apps/demo/src/components/FlashOverlay.tsx
@@ -43,8 +43,8 @@ const FlashOverlay = ({
         <Dialog title="Ready to pair" titleId="flash-dialog-title">
           <p>Press reset on the micro:bit three times.</p>
           <p>
-            If your micro:bit has not been updated in a while, hold button A
-            and B and press reset.
+            If your micro:bit has not been updated in a while, hold button A and
+            B and press reset.
           </p>
           <div className="dialog-actions">
             <button
@@ -83,9 +83,10 @@ const FlashOverlay = ({
       );
 
     case "flashing": {
-      const progressPercent = step.progress !== undefined
-        ? Math.round(step.progress * 100)
-        : undefined;
+      const progressPercent =
+        step.progress !== undefined
+          ? Math.round(step.progress * 100)
+          : undefined;
       return (
         <Dialog title="Flashing..." titleId="flash-dialog-title">
           {progressPercent !== undefined && (
@@ -131,9 +132,7 @@ const FlashOverlay = ({
                 ))}
                 <tr className="timing-total">
                   <td>Total</td>
-                  <td className="timing-value">
-                    {(total / 1000).toFixed(1)}s
-                  </td>
+                  <td className="timing-value">{(total / 1000).toFixed(1)}s</td>
                 </tr>
               </tbody>
             </table>
@@ -149,7 +148,11 @@ const FlashOverlay = ({
 
     case "flash-error":
       return (
-        <Dialog title="Flash failed" titleId="flash-dialog-title" titleStyle={{ color: "#dc2626" }}>
+        <Dialog
+          title="Flash failed"
+          titleId="flash-dialog-title"
+          titleStyle={{ color: "#dc2626" }}
+        >
           <p>{step.children}</p>
           <div className="dialog-actions">
             <button

--- a/apps/demo/src/components/FlashTab.tsx
+++ b/apps/demo/src/components/FlashTab.tsx
@@ -10,22 +10,86 @@ interface CannedHexFile {
 }
 
 const cannedHexFiles: CannedHexFile[] = [
-  { name: "bluetooth-v1-no-magnetometer.hex", path: "/hex-files/bluetooth-v1-no-magnetometer.hex", label: "Bluetooth V1 (No Magnetometer)" },
-  { name: "bluetooth-v2.hex", path: "/hex-files/bluetooth-v2.hex", label: "Bluetooth V2" },
-  { name: "data-collection-program.hex", path: "/hex-files/data-collection-program.hex", label: "Data Collection Program" },
-  { name: "serial-counter-makecode.hex", path: "/hex-files/serial-counter-makecode.hex", label: "Serial Counter (MakeCode)" },
-  { name: "serial-counter-python.hex", path: "/hex-files/serial-counter-python.hex", label: "Serial Counter (Python)" },
-  { name: "microbit-data-collection-just-works-universal.hex", path: "/hex-files/microbit-data-collection-just-works-universal.hex", label: "Data Collection (new, just works)" },
-  { name: "microbit-data-collection-no-pairing-universal.hex", path: "/hex-files/microbit-data-collection-no-pairing-universal.hex", label: "Data Collection (new, no pairing)" },
-  { name: "local-sensors-radio-bridge.hex", path: "/hex-files/local-sensors-radio-bridge.hex", label: "Local Sensors Radio Bridge" },
-  { name: "createai-project.hex", path: "/hex-files/createai-project.hex", label: "CreateAI project" },
-  { name: "meet-the-microbit.hex", path: "/hex-files/meet-the-microbit.hex", label: "Meet the micro:bit" },
-  { name: "microbit-beating-heart.hex", path: "/hex-files/microbit-beating-heart.hex", label: "Beating Heart" },
-  { name: "microbit-micropython-v1.hex", path: "/hex-files/microbit-micropython-v1.hex", label: "MicroPython V1" },
-  { name: "microbit-micropython-v2.hex", path: "/hex-files/microbit-micropython-v2.hex", label: "MicroPython V2" },
-  { name: "microbit-v1-battery-level.hex", path: "/hex-files/microbit-v1-battery-level.hex", label: "V1 Battery Level" },
-  { name: "microbit-v2-battery-voltage-v1.0.0.hex", path: "/hex-files/microbit-v2-battery-voltage-v1.0.0.hex", label: "V2 Battery Voltage" },
-  { name: "python-editor-default.hex", path: "/hex-files/python-editor-default.hex", label: "Python Editor Default" },
+  {
+    name: "bluetooth-v1-no-magnetometer.hex",
+    path: "/hex-files/bluetooth-v1-no-magnetometer.hex",
+    label: "Bluetooth V1 (No Magnetometer)",
+  },
+  {
+    name: "bluetooth-v2.hex",
+    path: "/hex-files/bluetooth-v2.hex",
+    label: "Bluetooth V2",
+  },
+  {
+    name: "data-collection-program.hex",
+    path: "/hex-files/data-collection-program.hex",
+    label: "Data Collection Program",
+  },
+  {
+    name: "serial-counter-makecode.hex",
+    path: "/hex-files/serial-counter-makecode.hex",
+    label: "Serial Counter (MakeCode)",
+  },
+  {
+    name: "serial-counter-python.hex",
+    path: "/hex-files/serial-counter-python.hex",
+    label: "Serial Counter (Python)",
+  },
+  {
+    name: "microbit-data-collection-just-works-universal.hex",
+    path: "/hex-files/microbit-data-collection-just-works-universal.hex",
+    label: "Data Collection (new, just works)",
+  },
+  {
+    name: "microbit-data-collection-no-pairing-universal.hex",
+    path: "/hex-files/microbit-data-collection-no-pairing-universal.hex",
+    label: "Data Collection (new, no pairing)",
+  },
+  {
+    name: "local-sensors-radio-bridge.hex",
+    path: "/hex-files/local-sensors-radio-bridge.hex",
+    label: "Local Sensors Radio Bridge",
+  },
+  {
+    name: "createai-project.hex",
+    path: "/hex-files/createai-project.hex",
+    label: "CreateAI project",
+  },
+  {
+    name: "meet-the-microbit.hex",
+    path: "/hex-files/meet-the-microbit.hex",
+    label: "Meet the micro:bit",
+  },
+  {
+    name: "microbit-beating-heart.hex",
+    path: "/hex-files/microbit-beating-heart.hex",
+    label: "Beating Heart",
+  },
+  {
+    name: "microbit-micropython-v1.hex",
+    path: "/hex-files/microbit-micropython-v1.hex",
+    label: "MicroPython V1",
+  },
+  {
+    name: "microbit-micropython-v2.hex",
+    path: "/hex-files/microbit-micropython-v2.hex",
+    label: "MicroPython V2",
+  },
+  {
+    name: "microbit-v1-battery-level.hex",
+    path: "/hex-files/microbit-v1-battery-level.hex",
+    label: "V1 Battery Level",
+  },
+  {
+    name: "microbit-v2-battery-voltage-v1.0.0.hex",
+    path: "/hex-files/microbit-v2-battery-voltage-v1.0.0.hex",
+    label: "V2 Battery Voltage",
+  },
+  {
+    name: "python-editor-default.hex",
+    path: "/hex-files/python-editor-default.hex",
+    label: "Python Editor Default",
+  },
 ];
 
 const FlashTab = () => {

--- a/apps/demo/src/components/LedGrid.tsx
+++ b/apps/demo/src/components/LedGrid.tsx
@@ -9,12 +9,7 @@ interface LedGridProps {
   gap?: number;
 }
 
-const LedGrid = ({
-  grid,
-  onToggle,
-  cellSize = 44,
-  gap = 4,
-}: LedGridProps) => {
+const LedGrid = ({ grid, onToggle, cellSize = 44, gap = 4 }: LedGridProps) => {
   return (
     <div
       className="led-grid"

--- a/apps/demo/src/components/LedsTab.tsx
+++ b/apps/demo/src/components/LedsTab.tsx
@@ -8,7 +8,11 @@ import LedGrid from "./LedGrid.tsx";
 const emptyMatrix = (): boolean[][] =>
   Array.from({ length: 5 }, () => Array(5).fill(false));
 
-const TextSection = ({ connection }: { connection: MicrobitBluetoothConnection }) => {
+const TextSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
   const { log } = useLog();
   const { showError } = useErrorDialog();
   const [text, setText] = useState("");
@@ -17,7 +21,9 @@ const TextSection = ({ connection }: { connection: MicrobitBluetoothConnection }
     try {
       await connection.setLedText(text);
       log("led", `Text set: "${text}"`);
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, text, log, showError]);
 
   return (
@@ -32,13 +38,19 @@ const TextSection = ({ connection }: { connection: MicrobitBluetoothConnection }
           className="input"
           style={{ width: 200 }}
         />
-        <button onClick={sendText} className="btn btn-primary">Write</button>
+        <button onClick={sendText} className="btn btn-primary">
+          Write
+        </button>
       </div>
     </div>
   );
 };
 
-const ScrollingDelaySection = ({ connection }: { connection: MicrobitBluetoothConnection }) => {
+const ScrollingDelaySection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
   const { log } = useLog();
   const { showError } = useErrorDialog();
   const [delay, setDelay] = useState("");
@@ -49,14 +61,18 @@ const ScrollingDelaySection = ({ connection }: { connection: MicrobitBluetoothCo
       if (d !== undefined) {
         setDelay(String(d));
       }
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, showError]);
 
   const setDelayValue = useCallback(async () => {
     try {
       await connection.setLedScrollingDelay(parseInt(delay, 10));
       log("led", `Scrolling delay set to ${delay}ms`);
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, delay, log, showError]);
 
   return (
@@ -71,14 +87,22 @@ const ScrollingDelaySection = ({ connection }: { connection: MicrobitBluetoothCo
           className="input"
           style={{ width: 100 }}
         />
-        <button onClick={getDelay} className="btn">Read</button>
-        <button onClick={setDelayValue} className="btn">Write</button>
+        <button onClick={getDelay} className="btn">
+          Read
+        </button>
+        <button onClick={setDelayValue} className="btn">
+          Write
+        </button>
       </div>
     </div>
   );
 };
 
-const MatrixSection = ({ connection }: { connection: MicrobitBluetoothConnection }) => {
+const MatrixSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
   const { log } = useLog();
   const { showError } = useErrorDialog();
   const [matrix, setMatrix] = useState<boolean[][]>(emptyMatrix);
@@ -87,14 +111,18 @@ const MatrixSection = ({ connection }: { connection: MicrobitBluetoothConnection
     try {
       const m = await connection.getLedMatrix();
       setMatrix(m);
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, showError]);
 
   const sendMatrix = useCallback(async () => {
     try {
       await connection.setLedMatrix(matrix);
       log("led", "Matrix updated");
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, matrix, log, showError]);
 
   const handleToggle = useCallback((row: number, col: number) => {
@@ -108,16 +136,17 @@ const MatrixSection = ({ connection }: { connection: MicrobitBluetoothConnection
   return (
     <div className="section">
       <h2>Matrix</h2>
-      <LedGrid
-        grid={matrix}
-        onToggle={handleToggle}
-        cellSize={32}
-        gap={3}
-      />
+      <LedGrid grid={matrix} onToggle={handleToggle} cellSize={32} gap={3} />
       <div className="control-row" style={{ marginTop: 8 }}>
-        <button onClick={getMatrix} className="btn">Read</button>
-        <button onClick={sendMatrix} className="btn">Write</button>
-        <button onClick={() => setMatrix(emptyMatrix())} className="btn">Reset grid</button>
+        <button onClick={getMatrix} className="btn">
+          Read
+        </button>
+        <button onClick={sendMatrix} className="btn">
+          Write
+        </button>
+        <button onClick={() => setMatrix(emptyMatrix())} className="btn">
+          Reset grid
+        </button>
       </div>
     </div>
   );

--- a/apps/demo/src/components/LogPanel.tsx
+++ b/apps/demo/src/components/LogPanel.tsx
@@ -41,7 +41,15 @@ const LogPanel = () => {
         )}
       </div>
       {isOpen && (
-        <div id="log-panel-content" style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+        <div
+          id="log-panel-content"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            minHeight: 0,
+          }}
+        >
           <div
             role="log"
             aria-live="polite"
@@ -50,9 +58,15 @@ const LogPanel = () => {
           >
             {entries.map((entry) => {
               const time = new Date(entry.timestamp);
-              const ts = time.toTimeString().slice(0, 8) + "." + String(time.getMilliseconds()).padStart(3, "0");
+              const ts =
+                time.toTimeString().slice(0, 8) +
+                "." +
+                String(time.getMilliseconds()).padStart(3, "0");
               return (
-                <div key={entry.id} style={{ whiteSpace: "pre-wrap", lineHeight: 1.4 }}>
+                <div
+                  key={entry.id}
+                  style={{ whiteSpace: "pre-wrap", lineHeight: 1.4 }}
+                >
                   <span style={{ color: "#737373" }}>{ts}</span>{" "}
                   <span style={{ color: levelColors[entry.level] ?? "#666" }}>
                     [{entry.source}]

--- a/apps/demo/src/components/PinsTab.tsx
+++ b/apps/demo/src/components/PinsTab.tsx
@@ -35,7 +35,10 @@ const PinConfigSection = ({
     try {
       await connection.setAnalogPins([...analogPins]);
       await connection.setInputPins([...inputPins]);
-      log("pins", `Config written — analog: [${[...analogPins]}], input: [${[...inputPins]}]`);
+      log(
+        "pins",
+        `Config written — analog: [${[...analogPins]}], input: [${[...inputPins]}]`,
+      );
     } catch (e) {
       showError(e);
     }
@@ -60,10 +63,14 @@ const PinConfigSection = ({
   return (
     <div className="section">
       <h2>Pin Configuration</h2>
-      <table style={{ fontSize: 13, borderCollapse: "collapse", marginBottom: 8 }}>
+      <table
+        style={{ fontSize: 13, borderCollapse: "collapse", marginBottom: 8 }}
+      >
         <thead>
           <tr>
-            <th style={{ padding: "4px 12px 4px 0", textAlign: "left" }}>Pin</th>
+            <th style={{ padding: "4px 12px 4px 0", textAlign: "left" }}>
+              Pin
+            </th>
             <th style={{ padding: "4px 12px" }}>Analog</th>
             <th style={{ padding: "4px 12px" }}>Input</th>
           </tr>
@@ -71,7 +78,9 @@ const PinConfigSection = ({
         <tbody>
           {PINS.map((pin) => (
             <tr key={pin}>
-              <td style={{ padding: "4px 12px 4px 0", fontWeight: 600 }}>P{pin}</td>
+              <td style={{ padding: "4px 12px 4px 0", fontWeight: 600 }}>
+                P{pin}
+              </td>
               <td style={{ padding: "4px 12px", textAlign: "center" }}>
                 <input
                   type="checkbox"
@@ -91,8 +100,12 @@ const PinConfigSection = ({
         </tbody>
       </table>
       <div className="control-row">
-        <button onClick={readConfig} className="btn">Read</button>
-        <button onClick={writeConfig} className="btn">Write</button>
+        <button onClick={readConfig} className="btn">
+          Read
+        </button>
+        <button onClick={writeConfig} className="btn">
+          Write
+        </button>
       </div>
     </div>
   );
@@ -135,7 +148,10 @@ const PinDataSection = ({
         next.set(pv.pin, pv.value);
       }
       setPinValues(next);
-      log("pins", `Read: ${data.map((d) => `P${d.pin}=${d.value}`).join(", ") || "(none)"}`);
+      log(
+        "pins",
+        `Read: ${data.map((d) => `P${d.pin}=${d.value}`).join(", ") || "(none)"}`,
+      );
     } catch (e) {
       showError(e);
     }
@@ -163,7 +179,9 @@ const PinDataSection = ({
         >
           {listening ? "Stop" : "Listen"}
         </button>
-        <button onClick={readAll} className="btn">Read</button>
+        <button onClick={readAll} className="btn">
+          Read
+        </button>
       </div>
       {displayPins.length > 0 ? (
         <div className="sensor-readout">
@@ -191,7 +209,9 @@ const PinDataSection = ({
           onChange={(e) => setWritePin(parseInt(e.target.value, 10))}
         >
           {PINS.map((p) => (
-            <option key={p} value={p}>P{p}</option>
+            <option key={p} value={p}>
+              P{p}
+            </option>
           ))}
         </select>
         <input
@@ -202,7 +222,9 @@ const PinDataSection = ({
           className="input"
           style={{ width: 60 }}
         />
-        <button onClick={writePin_} className="btn">Write</button>
+        <button onClick={writePin_} className="btn">
+          Write
+        </button>
       </div>
     </div>
   );
@@ -240,10 +262,19 @@ const PwmSection = ({
           onChange={(e) => setPin(parseInt(e.target.value, 10))}
         >
           {PINS.map((p) => (
-            <option key={p} value={p}>P{p}</option>
+            <option key={p} value={p}>
+              P{p}
+            </option>
           ))}
         </select>
-        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           Value:
           <input
             type="number"
@@ -254,7 +285,14 @@ const PwmSection = ({
             placeholder="0-1024"
           />
         </label>
-        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           Period (us):
           <input
             type="number"
@@ -264,7 +302,9 @@ const PwmSection = ({
             style={{ width: 80 }}
           />
         </label>
-        <button onClick={writePwm} className="btn">Write</button>
+        <button onClick={writePwm} className="btn">
+          Write
+        </button>
       </div>
     </div>
   );

--- a/apps/demo/src/components/SensorsTab.tsx
+++ b/apps/demo/src/components/SensorsTab.tsx
@@ -15,7 +15,11 @@ type ServiceConnection =
   | MicrobitBluetoothConnection
   | MicrobitRadioBridgeConnection;
 
-const AxisReadout = ({ data }: { data: { x: number; y: number; z: number } }) => (
+const AxisReadout = ({
+  data,
+}: {
+  data: { x: number; y: number; z: number };
+}) => (
   <div className="sensor-readout">
     <span className="axis">
       <span className="axis-label">x:</span>
@@ -32,7 +36,11 @@ const AxisReadout = ({ data }: { data: { x: number; y: number; z: number } }) =>
   </div>
 );
 
-const AccelerometerSection = ({ connection }: { connection: ServiceConnection }) => {
+const AccelerometerSection = ({
+  connection,
+}: {
+  connection: ServiceConnection;
+}) => {
   const { log } = useLog();
   const { showError } = useErrorDialog();
   const [data, setData] = useState<AccelerometerData | null>(null);
@@ -54,7 +62,9 @@ const AccelerometerSection = ({ connection }: { connection: ServiceConnection })
         const p = await connection.getAccelerometerPeriod();
         setPeriod(String(p));
       }
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, showError]);
 
   const setPeriodValue = useCallback(async () => {
@@ -63,7 +73,9 @@ const AccelerometerSection = ({ connection }: { connection: ServiceConnection })
         await connection.setAccelerometerPeriod(parseInt(period, 10));
         log("accel", `Period set to ${period}ms`);
       }
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, period, log, showError]);
 
   return (
@@ -77,14 +89,25 @@ const AccelerometerSection = ({ connection }: { connection: ServiceConnection })
           {listening ? "Stop" : "Listen"}
         </button>
       </div>
-      {data ? <AxisReadout data={data} /> : (
+      {data ? (
+        <AxisReadout data={data} />
+      ) : (
         <p className="empty-state">
-          {listening ? "Waiting for data..." : "Press Listen to start receiving accelerometer data."}
+          {listening
+            ? "Waiting for data..."
+            : "Press Listen to start receiving accelerometer data."}
         </p>
       )}
       {connection.type === "bluetooth" && (
         <div className="control-row" style={{ marginTop: 8 }}>
-          <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+          <label
+            style={{
+              fontSize: 13,
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
             Period (ms):
             <input
               type="number"
@@ -94,15 +117,23 @@ const AccelerometerSection = ({ connection }: { connection: ServiceConnection })
               style={{ width: 80 }}
             />
           </label>
-          <button onClick={getPeriod} className="btn">Read</button>
-          <button onClick={setPeriodValue} className="btn">Write</button>
+          <button onClick={getPeriod} className="btn">
+            Read
+          </button>
+          <button onClick={setPeriodValue} className="btn">
+            Write
+          </button>
         </div>
       )}
     </div>
   );
 };
 
-const MagnetometerSection = ({ connection }: { connection: MicrobitBluetoothConnection }) => {
+const MagnetometerSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
   const { log } = useLog();
   const { showError } = useErrorDialog();
   const [data, setData] = useState<MagnetometerData | null>(null);
@@ -123,14 +154,18 @@ const MagnetometerSection = ({ connection }: { connection: MicrobitBluetoothConn
     try {
       const p = await connection.getMagnetometerPeriod();
       setPeriod(String(p));
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, showError]);
 
   const setPeriodValue = useCallback(async () => {
     try {
       await connection.setMagnetometerPeriod(parseInt(period, 10));
       log("mag", `Period set to ${period}ms`);
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, period, log, showError]);
 
   const handleGetBearing = useCallback(async () => {
@@ -138,14 +173,18 @@ const MagnetometerSection = ({ connection }: { connection: MicrobitBluetoothConn
       const b = await connection.getMagnetometerBearing();
       setBearing(b);
       log("mag", `Bearing: ${b} degrees`);
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, log, showError]);
 
   const handleCalibrate = useCallback(async () => {
     try {
       log("mag", "Triggering calibration...");
       await connection.triggerMagnetometerCalibration();
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, log, showError]);
 
   return (
@@ -159,13 +198,24 @@ const MagnetometerSection = ({ connection }: { connection: MicrobitBluetoothConn
           {listening ? "Stop" : "Listen"}
         </button>
       </div>
-      {data ? <AxisReadout data={data} /> : (
+      {data ? (
+        <AxisReadout data={data} />
+      ) : (
         <p className="empty-state">
-          {listening ? "Waiting for data..." : "Press Listen to start receiving magnetometer data."}
+          {listening
+            ? "Waiting for data..."
+            : "Press Listen to start receiving magnetometer data."}
         </p>
       )}
       <div className="control-row" style={{ marginTop: 8 }}>
-        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           Period (ms):
           <input
             type="number"
@@ -175,8 +225,12 @@ const MagnetometerSection = ({ connection }: { connection: MicrobitBluetoothConn
             style={{ width: 80 }}
           />
         </label>
-        <button onClick={getPeriod} className="btn">Read</button>
-        <button onClick={setPeriodValue} className="btn">Write</button>
+        <button onClick={getPeriod} className="btn">
+          Read
+        </button>
+        <button onClick={setPeriodValue} className="btn">
+          Write
+        </button>
       </div>
       <div className="control-row" style={{ marginTop: 8 }}>
         <button onClick={handleCalibrate} className="btn">
@@ -187,13 +241,19 @@ const MagnetometerSection = ({ connection }: { connection: MicrobitBluetoothConn
         </button>
       </div>
       {bearing !== null && (
-        <p style={{ fontSize: 13, margin: "8px 0 0" }}>Bearing: {bearing} degrees</p>
+        <p style={{ fontSize: 13, margin: "8px 0 0" }}>
+          Bearing: {bearing} degrees
+        </p>
       )}
     </div>
   );
 };
 
-const TemperatureSection = ({ connection }: { connection: MicrobitBluetoothConnection }) => {
+const TemperatureSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
   const { log } = useLog();
   const { showError } = useErrorDialog();
   const [celsius, setCelsius] = useState<number | null>(null);
@@ -214,21 +274,27 @@ const TemperatureSection = ({ connection }: { connection: MicrobitBluetoothConne
       const t = await connection.getTemperature();
       setCelsius(t);
       log("temp", `Temperature: ${t} °C`);
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, log, showError]);
 
   const getPeriod = useCallback(async () => {
     try {
       const p = await connection.getTemperaturePeriod();
       setPeriod(String(p));
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, showError]);
 
   const setPeriodValue = useCallback(async () => {
     try {
       await connection.setTemperaturePeriod(parseInt(period, 10));
       log("temp", `Period set to ${period}ms`);
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, period, log, showError]);
 
   return (
@@ -241,21 +307,34 @@ const TemperatureSection = ({ connection }: { connection: MicrobitBluetoothConne
         >
           {listening ? "Stop" : "Listen"}
         </button>
-        <button onClick={readTemperature} className="btn">Read</button>
+        <button onClick={readTemperature} className="btn">
+          Read
+        </button>
       </div>
       {celsius !== null ? (
         <div className="sensor-readout">
           <span className="axis">
-            <span className="axis-value" style={{ minWidth: 40 }}>{celsius} °C</span>
+            <span className="axis-value" style={{ minWidth: 40 }}>
+              {celsius} °C
+            </span>
           </span>
         </div>
       ) : (
         <p className="empty-state">
-          {listening ? "Waiting for data..." : "Press Listen or Read to get temperature."}
+          {listening
+            ? "Waiting for data..."
+            : "Press Listen or Read to get temperature."}
         </p>
       )}
       <div className="control-row" style={{ marginTop: 8 }}>
-        <label style={{ fontSize: 13, display: "flex", alignItems: "center", gap: 4 }}>
+        <label
+          style={{
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
           Period (ms):
           <input
             type="number"
@@ -265,8 +344,12 @@ const TemperatureSection = ({ connection }: { connection: MicrobitBluetoothConne
             style={{ width: 80 }}
           />
         </label>
-        <button onClick={getPeriod} className="btn">Read</button>
-        <button onClick={setPeriodValue} className="btn">Write</button>
+        <button onClick={getPeriod} className="btn">
+          Read
+        </button>
+        <button onClick={setPeriodValue} className="btn">
+          Write
+        </button>
       </div>
     </div>
   );
@@ -310,11 +393,15 @@ const ButtonsSection = ({ connection }: { connection: ServiceConnection }) => {
       <div className="sensor-readout" style={{ marginTop: 8 }}>
         <span className="axis">
           <span className="axis-label">A:</span>
-          <span className="axis-value" style={{ minWidth: 32 }}>{buttonA}</span>
+          <span className="axis-value" style={{ minWidth: 32 }}>
+            {buttonA}
+          </span>
         </span>
         <span className="axis">
           <span className="axis-label">B:</span>
-          <span className="axis-value" style={{ minWidth: 32 }}>{buttonB}</span>
+          <span className="axis-value" style={{ minWidth: 32 }}>
+            {buttonB}
+          </span>
         </span>
       </div>
     </div>

--- a/apps/demo/src/components/SerialTab.tsx
+++ b/apps/demo/src/components/SerialTab.tsx
@@ -71,7 +71,9 @@ const SerialTab = () => {
           </div>
         ) : (
           <p className="empty-state">
-            {serialListening ? "Waiting for serial data..." : "Press Listen to start receiving serial data."}
+            {serialListening
+              ? "Waiting for serial data..."
+              : "Press Listen to start receiving serial data."}
           </p>
         )}
       </div>

--- a/apps/demo/src/components/UartTab.tsx
+++ b/apps/demo/src/components/UartTab.tsx
@@ -5,7 +5,11 @@ import { useConnection } from "../hooks/use-connection.ts";
 import { useLog } from "../hooks/use-log.ts";
 import { useErrorDialog } from "../hooks/use-error-dialog.ts";
 
-const ReceiveSection = ({ connection }: { connection: MicrobitBluetoothConnection }) => {
+const ReceiveSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
   const { log } = useLog();
   const [lines, setLines] = useState<string[]>([]);
   const [listening, setListening] = useState(false);
@@ -54,14 +58,20 @@ const ReceiveSection = ({ connection }: { connection: MicrobitBluetoothConnectio
         </div>
       ) : (
         <p className="empty-state">
-          {listening ? "Waiting for UART data..." : "Press Listen to start receiving UART data."}
+          {listening
+            ? "Waiting for UART data..."
+            : "Press Listen to start receiving UART data."}
         </p>
       )}
     </div>
   );
 };
 
-const WriteSection = ({ connection }: { connection: MicrobitBluetoothConnection }) => {
+const WriteSection = ({
+  connection,
+}: {
+  connection: MicrobitBluetoothConnection;
+}) => {
   const { log } = useLog();
   const { showError } = useErrorDialog();
   const [text, setText] = useState("");
@@ -71,7 +81,9 @@ const WriteSection = ({ connection }: { connection: MicrobitBluetoothConnection 
       const encoded = new TextEncoder().encode(text);
       await connection.uartWrite(encoded);
       log("uart", `Sent: ${text}`);
-    } catch (e) { showError(e); }
+    } catch (e) {
+      showError(e);
+    }
   }, [connection, text, log, showError]);
 
   return (

--- a/apps/demo/src/hooks/use-connection.ts
+++ b/apps/demo/src/hooks/use-connection.ts
@@ -23,9 +23,8 @@ import { Capacitor } from "@capacitor/core";
 import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { useLog, createLoggingAdapter } from "./use-log.ts";
 
-const defaultConnectionType: AnyConnection["type"] = Capacitor.isNativePlatform()
-  ? "bluetooth"
-  : "usb";
+const defaultConnectionType: AnyConnection["type"] =
+  Capacitor.isNativePlatform() ? "bluetooth" : "usb";
 
 export type AnyConnection =
   | MicrobitUSBConnection
@@ -49,7 +48,9 @@ export const ConnectionContext = createContext<
 
 export const useConnectionState = (): ConnectionContextValue | undefined => {
   const { log } = useLog();
-  const [connectionType, setConnectionType] = useState<AnyConnection["type"]>(defaultConnectionType);
+  const [connectionType, setConnectionType] = useState<AnyConnection["type"]>(
+    defaultConnectionType,
+  );
   const [pauseOnHidden, setPauseOnHidden] = useState(true);
   const [bondMode, setBondMode] = useState<BondMode>("pairing");
   const [status, setStatus] = useState<ConnectionStatus>(
@@ -105,16 +106,15 @@ export const useConnectionState = (): ConnectionContextValue | undefined => {
       setStatus(e.status);
       if (e.status === ConnectionStatus.Connected) {
         setBoardVersion(conn.getBoardVersion());
-      } else if (e.status === ConnectionStatus.Disconnected || e.status === ConnectionStatus.NoAuthorizedDevice) {
+      } else if (
+        e.status === ConnectionStatus.Disconnected ||
+        e.status === ConnectionStatus.NoAuthorizedDevice
+      ) {
         setBoardVersion(undefined);
       }
     };
     const errorListener = (e: BackgroundErrorData) => {
-      log(
-        "connection",
-        `Error: ${e.error.code} ${e.error.message}`,
-        "error",
-      );
+      log("connection", `Error: ${e.error.code} ${e.error.message}`, "error");
     };
 
     conn.addEventListener("status", statusListener);

--- a/apps/demo/src/hooks/use-error-dialog.ts
+++ b/apps/demo/src/hooks/use-error-dialog.ts
@@ -27,8 +27,7 @@ export const useErrorDialogState = (): ErrorDialogContextValue => {
       return;
     }
     const code = err instanceof DeviceError ? err.code : undefined;
-    const message =
-      err instanceof Error ? err.message : String(err);
+    const message = err instanceof Error ? err.message : String(err);
     setError({ code, message });
   }, []);
 

--- a/apps/demo/src/hooks/use-log.ts
+++ b/apps/demo/src/hooks/use-log.ts
@@ -58,9 +58,7 @@ export const useLog = (): LogContextValue => {
  * Creates a Logging implementation that bridges library internal logs
  * to our LogContext.
  */
-export const createLoggingAdapter = (
-  log: LogContextValue["log"],
-): Logging => ({
+export const createLoggingAdapter = (log: LogContextValue["log"]): Logging => ({
   event(event: LoggingEvent) {
     const parts = [event.type];
     if (event.message) parts.push(event.message);

--- a/apps/hardware-test/src/main.ts
+++ b/apps/hardware-test/src/main.ts
@@ -100,7 +100,9 @@ function createUSBSuite({
             `Serial active before flash (got ${ctx.serial.numbers.length} numbers)`,
           );
           const resetsBefore = ctx.serial.resetCount;
-          ctx.log("Flashing Python on fresh USB connection (runtime change)...");
+          ctx.log(
+            "Flashing Python on fresh USB connection (runtime change)...",
+          );
           const hex = await ctx.fetchHex("serial-counter-python.hex");
           const stages = await flashWithProgress(ctx, hex);
           assertFlashType(ctx, stages, "FullFlashing");
@@ -147,11 +149,10 @@ function createUSBSuite({
           // partial flashing skips addresses >= 0x10000000. ensureUicr()
           // should have detected the blank UICR and repaired it.
           ctx.assertLogged("UICR mismatch", "Library detected UICR mismatch");
-          ctx.assertLogged(
-            "UICR repair complete",
-            "Library repaired UICR",
+          ctx.assertLogged("UICR repair complete", "Library repaired UICR");
+          ctx.log(
+            "Flashing serial-counter-python.hex to verify device boots...",
           );
-          ctx.log("Flashing serial-counter-python.hex to verify device boots...");
           const verifyHex = await ctx.fetchHex("serial-counter-python.hex");
           await flashWithProgress(ctx, verifyHex);
           ctx.log("Checking device boots after UICR recovery...");
@@ -186,9 +187,7 @@ async function replugAndReconnect(
     ctx.connection.status === ConnectionStatus.NoAuthorizedDevice,
     "Device lost after unplug",
   );
-  await ctx.waitForUser(
-    "Plug the micro:bit back in, then click Continue.",
-  );
+  await ctx.waitForUser("Plug the micro:bit back in, then click Continue.");
   ctx.log("Reconnecting...");
   await ctx.connection.connect();
   await ctx.waitForStatus(ConnectionStatus.Connected, 15_000);
@@ -203,10 +202,7 @@ async function replugAndReconnect(
 }
 
 function assertConnected(ctx: TestContext): void {
-  ctx.assert(
-    ctx.connection.status === ConnectionStatus.Connected,
-    "Connected",
-  );
+  ctx.assert(ctx.connection.status === ConnectionStatus.Connected, "Connected");
 }
 
 async function flashWithProgress(
@@ -281,7 +277,10 @@ async function assertSerialFromZero(
 ): Promise<void> {
   const numbers = await ctx.serial.waitForNumbers(count, timeoutMs);
   ctx.log(`Received: ${numbers.join(", ")}`);
-  ctx.assert(numbers.length >= count, `Got ${numbers.length} numbers (need ${count})`);
+  ctx.assert(
+    numbers.length >= count,
+    `Got ${numbers.length} numbers (need ${count})`,
+  );
   ctx.assert(numbers[0] === 0, `First number is 0 (got ${numbers[0]})`);
   for (let i = 1; i < numbers.length; i++) {
     ctx.assert(

--- a/apps/hardware-test/src/runner.ts
+++ b/apps/hardware-test/src/runner.ts
@@ -308,8 +308,7 @@ export class TestRunner {
         }
         this.appendLog(test, `PASS: ${msg}`, "success");
       },
-      waitForUser: (instruction: string) =>
-        this.waitForUser(test, instruction),
+      waitForUser: (instruction: string) => this.waitForUser(test, instruction),
       waitForStatus: (
         status: ConnectionStatus,
         timeoutMs = 10_000,

--- a/apps/hardware-test/src/style.css
+++ b/apps/hardware-test/src/style.css
@@ -5,7 +5,10 @@
 }
 
 body {
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
   max-width: 800px;
   margin: 0 auto;
   padding: 20px;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:lib": "npm run build -w @microbit/microbit-connection",
     "dev": "npm run dev -w @microbit/microbit-connection-demo",
     "test": "npm run test -w @microbit/microbit-connection",
-    "ci": "npm run build && npm run test && npm run format:check",
+    "ci": "npm run build && npm run test",
     "format": "prettier --write --list-different .",
     "format:check": "prettier --check .",
     "docs": "npm run docs -w @microbit/microbit-connection"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "dev": "npm run dev -w @microbit/microbit-connection-demo",
     "test": "npm run test -w @microbit/microbit-connection",
     "ci": "npm run build && npm run test && npm run format:check",
-    "format": "prettier --write --list-different packages/*/src",
-    "format:check": "prettier --check packages/*/src",
+    "format": "prettier --write --list-different .",
+    "format:check": "prettier --check .",
     "docs": "npm run docs -w @microbit/microbit-connection"
   },
   "devDependencies": {


### PR DESCRIPTION
The format/format:check scripts only checked packages/*/src, so apps/ and root markdown drifted out of style. Widen the glob to "." with a .prettierignore that skips node_modules, build output, Capacitor native projects, hex files and the lockfile.