### PR TITLE
Start DFU as foreground service

### DIFF
--- a/packages/microbit-connection/src/bluetooth/flashing/nordic-dfu.ts
+++ b/packages/microbit-connection/src/bluetooth/flashing/nordic-dfu.ts
@@ -146,7 +146,7 @@ export async function flashDfu(
                   restoreBond: true,
                 },
               }[boardVersion],
-              startAsForegroundService: false,
+              startAsForegroundService: true,
               keepBond: true,
               packetReceiptNotificationsEnabled: true,
             }


### PR DESCRIPTION
So that the flashing progress is noticeable even if users are not directly interacting with the Android app.